### PR TITLE
Fixing ExternalIP address duplication bug

### DIFF
--- a/pkg/cloudprovider/yandex/instances.go
+++ b/pkg/cloudprovider/yandex/instances.go
@@ -105,9 +105,6 @@ func (yc *Cloud) extractNodeAddresses(ctx context.Context, instance *compute.Ins
 		}
 
 		nodeAddresses = []v1.NodeAddress{{Type: v1.NodeInternalIP, Address: networkInterface.PrimaryV4Address.Address}}
-		if networkInterface.PrimaryV4Address.OneToOneNat != nil {
-			nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeExternalIP, Address: networkInterface.PrimaryV4Address.OneToOneNat.Address})
-		}
 	}
 
 	if len(yc.config.ExternalNetworkIDsSet) > 0 {


### PR DESCRIPTION
Hello. This PR should fix bug with updating node status addresses field. Right now I am getting error message like this:
```
yandex-cloud-controller-manager-7zsww yandex-cloud-controller-manager E0128 21:22:57.074080       1 node_controller.go:363] Error patching node with cloud ip addresses = [failed to patch status "{\"status\":{\"addresses\":[{\"address\":\"10.0.2.21\",\"type\":\"InternalIP\"},{\"address\":\"x.x.x.x\",\"type\":\"ExternalIP\"},{\"address\":\"x.x.x.x\",\"type\":\"ExternalIP\"},{\"address\":\"infr-master-ru-central1-c-0\",\"type\":\"Hostname\"},{\"$patch\":\"replace\"}]}}" for node "infr-master-ru-central1-c-0": Node "infr-master-ru-central1-c-0" is invalid: status.addresses[2]: Duplicate value: core.NodeAddress{Type:"ExternalIP", Address:"x.x.x.x"}]
```
P.S.: ExternalIP address value replaced by `x.x.x.x` string for security reason.