### PR TITLE
add tg node annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ Due to API limitations, only one subnet from each zone must be present in each N
 * `yandex.cpi.flant.com/listener-address-ipv4` – select pre-defined IPv4 address. Works both on internal and external NetworkLoadBalancers.
 * `yandex.cpi.flant.com/loadbalancer-external` – override `YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID` per-service.
 
+##### Node annotations
+
+* `yandex.cpi.flant.com/target-group` - set node to the non-default target group add this annotation to the node.  Yandex CCM creates new target groups with name `yandex.cpi.flant.com/target-group` annotation value + network id of instance interfaces.
 ## Warning
 
 1. If masters are created with their own target groups, then you need to attach the `node.kubernetes.io/exclude-from-external-load-balancers: ""` label on them so that the controller does not try to add the master to a new target group for balancers

--- a/README.md
+++ b/README.md
@@ -129,10 +129,12 @@ Due to API limitations, only one subnet from each zone must be present in each N
 * `yandex.cpi.flant.com/listener-subnet-id` – default SubnetID to use for Listeners in created NetworkLoadBalancers. NetworkLoadBalancers will be INTERNAL.
 * `yandex.cpi.flant.com/listener-address-ipv4` – select pre-defined IPv4 address. Works both on internal and external NetworkLoadBalancers.
 * `yandex.cpi.flant.com/loadbalancer-external` – override `YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID` per-service.
+* `yandex.cpi.flant.com/target-group-name-prefix` - set target group for LB to target group with name `yandex.cpi.flant.com/target-group-name-prefix` annotation value + yandex cluster name + `YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID`.
 
 ##### Node annotations
 
-* `yandex.cpi.flant.com/target-group` - set node to the non-default target group add this annotation to the node.  Yandex CCM creates new target groups with name `yandex.cpi.flant.com/target-group` annotation value + network id of instance interfaces.
+* `yandex.cpi.flant.com/target-group-name-prefix` - set node to the non-default target group add this annotation to the node.  Yandex CCM creates new target groups with name `yandex.cpi.flant.com/target-group-name-prefix` annotation value + yandex cluster name + network id of instance interfaces.
+
 ## Warning
 
 1. If masters are created with their own target groups, then you need to attach the `node.kubernetes.io/exclude-from-external-load-balancers: ""` label on them so that the controller does not try to add the master to a new target group for balancers

--- a/pkg/yapi/loadbalancer.go
+++ b/pkg/yapi/loadbalancer.go
@@ -197,7 +197,7 @@ func (ySvc *LoadBalancerService) GetTGsByClusterName(ctx context.Context, cluste
 	}
 
 	for _, tg := range result.TargetGroups {
-		if strings.HasPrefix(tg.Name, clusterName) {
+		if strings.Contains(tg.Name, clusterName) {
 			ret = append(ret, tg)
 		}
 	}


### PR DESCRIPTION
To set node to the non-default target group add annotation `yandex.cpi.flant.com/target-group` to the node. Yandex CCM creates new target groups with name `yandex.cpi.flant.com/target-group` annotation value + network id of instance interfaces. 