### PR TITLE
feat: Make region and zone configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,46 @@ The `yandex-cloud-controller-manager` requires a [Service Account Json]([https:/
 * `YANDEX_CLOUD_FOLDER_ID`
 * `YANDEX_CLUSTER_NAME`
 
+### Region and Zone Configuration
+
+You can specify the operational region and zone for the controller manager. This is particularly useful for deployments outside the default `ru-central1-b` zone or when running on infrastructure that may not have access to the metadata service for zone discovery.
+
+*   `YANDEX_CLOUD_LOCAL_ZONE`: Specifies the Yandex Cloud zone the controller manager will operate in.
+    *   Example: `kz-central1-a`
+*   `YANDEX_CLOUD_LOCAL_REGION`: Specifies the Yandex Cloud region. If not set, it will be derived from the `YANDEX_CLOUD_LOCAL_ZONE`.
+    *   Example: `kz-central1`
+
+**Configuration Precedence:**
+
+*   **Zone:**
+    1.  Environment variable: `YANDEX_CLOUD_LOCAL_ZONE`
+    2.  Instance metadata service (if the controller can access it and the variable is not set)
+    3.  Default: `ru-central1-b`
+*   **Region:**
+    1.  Environment variable: `YANDEX_CLOUD_LOCAL_REGION`
+    2.  Derived from the effective zone (determined by the precedence above).
+
+**Setting these variables:**
+
+*   **Helm Chart:** When deploying using the Helm chart, you can set `localZone` and `localRegion` in your `values.yaml` file:
+    ```yaml
+    # In your values.yaml
+    localZone: "kz-central1-a"
+    localRegion: "kz-central1"
+    ```
+*   **Static Manifest:** If using the provided static manifest (`manifests/yandex-cloud-controller-manager.yaml`), you can directly edit the `env` section of the `yandex-cloud-controller-manager` container to set these variables:
+    ```yaml
+    # In manifests/yandex-cloud-controller-manager.yaml
+    # ...
+    env:
+      # ... other environment variables
+      - name: YANDEX_CLOUD_LOCAL_ZONE
+        value: "kz-central1-a" # Specify the Yandex Cloud zone
+      - name: YANDEX_CLOUD_LOCAL_REGION
+        value: "kz-central1"   # Specify the Yandex Cloud region
+    # ...
+    ```
+
 The default manifest is configured to set these environment variables from a secret named `yandex-cloud`:
 
 ```bash

--- a/charts/yandex-cloud-controller/templates/controller.yaml
+++ b/charts/yandex-cloud-controller/templates/controller.yaml
@@ -66,6 +66,15 @@ spec:
           - name: YANDEX_CLUSTER_NAME
             value: {{ $.Values.clusterName }}
 
+          - name: YANDEX_CLOUD_FOLDER_ID
+            value: {{ $.Values.folderID | quote }}
+
+          - name: YANDEX_CLOUD_LOCAL_ZONE
+            value: {{ $.Values.localZone | quote }}
+
+          - name: YANDEX_CLOUD_LOCAL_REGION
+            value: {{ $.Values.localRegion | quote }}
+
           - name: YANDEX_CLOUD_SERVICE_ACCOUNT_JSON
             valueFrom:
               secretKeyRef:
@@ -99,7 +108,6 @@ spec:
               secretKeyRef:
                 name: {{ include "yandex-cloud-controller.name" $ }}
                 key: routeTableID
-
         image: {{ .image.repository }}:{{ .image.tag | default (printf "v%s" $.Chart.AppVersion) }}
         imagePullPolicy: {{ .image.pullPolicy }}
 

--- a/charts/yandex-cloud-controller/values.yaml
+++ b/charts/yandex-cloud-controller/values.yaml
@@ -1,6 +1,8 @@
 
 serviceAccountJSON: ""
 folderID: ""
+localZone: ""
+localRegion: ""
 vpcID: ""
 routeTableID: ""
 

--- a/manifests/yandex-cloud-controller-manager.yaml
+++ b/manifests/yandex-cloud-controller-manager.yaml
@@ -68,3 +68,7 @@ spec:
               value: <COMMA_SEPARATED_INTERNAL_NETWORK_IDS>
             - name: YANDEX_CLOUD_EXTERNAL_NETWORK_IDS
               value: <COMMA_SEPARATED_EXTERNAL_NETWORK_IDS>
+            - name: YANDEX_CLOUD_LOCAL_ZONE
+              value: "<YOUR_ZONE>" # Specify the Yandex Cloud zone, e.g., kz-central1-a
+            - name: YANDEX_CLOUD_LOCAL_REGION
+              value: "<YOUR_REGION>" # Specify the Yandex Cloud region, e.g., kz-central1


### PR DESCRIPTION
This change introduces configurability for the Yandex Cloud region and zone used by the yandex-cloud-controller-manager. Previously, the zone was hardcoded to 'ru-central1-b'.

The following changes were made:

- Modified `pkg/cloudprovider/yandex/cloud.go`:
    - Introduced `YANDEX_CLOUD_LOCAL_ZONE` and `YANDEX_CLOUD_LOCAL_REGION` environment variables.
    - Zone determination priority:
        1. `YANDEX_CLOUD_LOCAL_ZONE` env var
        2. Instance metadata service 3. Default: "ru-central1-b"
    - Region determination priority: 1. `YANDEX_CLOUD_LOCAL_REGION` env var 2. Derived from the effective zone
- Updated Helm chart (`charts/yandex-cloud-controller/`):
    - Added `localZone` and `localRegion` to `values.yaml`.
    - Passed these values as environment variables in `templates/controller.yaml`.
- Updated static manifest (`manifests/yandex-cloud-controller-manager.yaml`):
    - Added `YANDEX_CLOUD_LOCAL_ZONE` and `YANDEX_CLOUD_LOCAL_REGION` environment variables with placeholder values.
- Updated `README.md`:
    - Documented the new environment variables, their purpose, configuration methods (Helm, static manifest), and precedence.

These changes allow you to deploy and use the controller manager in different Yandex Cloud regions and zones, such as Kazakhstan (kz).