### PR TITLE
[cloud-provider-yandex] Set provider ID if empty

### DIFF
--- a/pkg/cloudprovider/yandex/cloud.go
+++ b/pkg/cloudprovider/yandex/cloud.go
@@ -177,6 +177,7 @@ func (yc *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder,
 	yc.nodeTargetGroupSyncer = &NodeTargetGroupSyncer{
 		cloud:            yc,
 		serviceLister:    serviceInformer.Lister(),
+		nodeClient:       clientset.CoreV1().Nodes(),
 		lastVisitedNodes: mapset.NewSet(),
 	}
 

--- a/pkg/cloudprovider/yandex/load_balancer_tg_controller.go
+++ b/pkg/cloudprovider/yandex/load_balancer_tg_controller.go
@@ -16,8 +16,10 @@ import (
 	"github.com/yandex-cloud/go-genproto/yandex/cloud/loadbalancer/v1"
 	"github.com/yandex-cloud/go-genproto/yandex/cloud/vpc/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 
 	mapset "github.com/deckarep/golang-set"
@@ -31,6 +33,7 @@ type NodeTargetGroupSyncer struct {
 
 	lastVisitedNodes mapset.Set
 	serviceLister    corev1listers.ServiceLister
+	nodeClient       corev1client.NodeInterface
 
 	tgSyncLock sync.Mutex
 }
@@ -117,20 +120,14 @@ func (ntgs *NodeTargetGroupSyncer) synchronizeNodesWithTargetGroups(ctx context.
 	// TODO: speed up by not performing individual lookups
 	var instances []*instanceWithNodeInfo
 	for _, node := range nodes {
-		if node.Spec.ProviderID == "" {
-			return errors.Errorf("node %s ProviderID is empty", node.Name)
+		instance, providerID, err := ntgs.getInstanceAndEnsureProviderID(ctx, node)
+		if err != nil {
+			return err
 		}
 
-		if !(strings.Contains(node.Spec.ProviderID, "yandex")) {
-			log.Printf("node %s ProviderID is not yandex (%s), skipping", node.Name, node.Spec.ProviderID)
+		if !(strings.Contains(providerID, "yandex")) {
+			log.Printf("node %s ProviderID is not yandex (%s), skipping", node.Name, providerID)
 			continue
-		}
-
-		nodeName := MapNodeNameToInstanceName(types.NodeName(node.Name))
-		log.Printf("Finding Instance by Folder %q and Name %q", ntgs.cloud.config.FolderID, nodeName)
-		instance, err := ntgs.cloud.yandexService.ComputeSvc.FindInstanceByName(ctx, nodeName)
-		if err != nil || instance == nil {
-			return fmt.Errorf("failed to find Instance by its name: %s", err)
 		}
 
 		instances = append(instances, &instanceWithNodeInfo{Instance: instance, Node: node})
@@ -151,6 +148,32 @@ func (ntgs *NodeTargetGroupSyncer) synchronizeNodesWithTargetGroups(ctx context.
 	ntgs.lastVisitedNodes = newSet
 
 	return nil
+}
+
+func (ntgs *NodeTargetGroupSyncer) getInstanceAndEnsureProviderID(ctx context.Context, node *corev1.Node) (*compute.Instance, string, error) {
+	nodeName := MapNodeNameToInstanceName(types.NodeName(node.Name))
+	log.Printf("Finding Instance by Folder %q and Name %q", ntgs.cloud.config.FolderID, nodeName)
+	instance, err := ntgs.cloud.yandexService.ComputeSvc.FindInstanceByName(ctx, nodeName)
+	if err != nil || instance == nil {
+		return nil, "", fmt.Errorf("failed to find Instance by its name: %s", err)
+	}
+
+	providerID := node.Spec.ProviderID
+	if providerID != "" {
+		return instance, providerID, nil
+	}
+
+	providerID = fmt.Sprintf("%s://%s", providerName, instance.Id)
+	patch := []byte(fmt.Sprintf(`{"spec":{"providerID":"%s"}}`, providerID))
+
+	if _, err := ntgs.nodeClient.Patch(ctx, node.Name, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return nil, "", errors.Wrapf(err, "failed to patch ProviderID for node %s", node.Name)
+	}
+
+	node.Spec.ProviderID = providerID
+	log.Printf("Patched ProviderID for node %s to %s", node.Name, providerID)
+
+	return instance, providerID, nil
 }
 
 func (ntgs *NodeTargetGroupSyncer) constructTgNameToTargetMap(ctx context.Context, instances []*instanceWithNodeInfo) (tgNameToTargetMap, error) {


### PR DESCRIPTION
## Description
This PR adds a patch to the Yandex cloud-controller-manager to handle nodes with an empty providerID during load balancer target group
synchronization.

## Why do we need it, and what problem does it solve?
In some cases, a node may reach CCM reconciliation with an empty providerID, which causes target group sync to fail and breaks load balancer reconciliation. This change resolves the instance by node name, backfills the missing providerID, and allows reconciliation to proceed normally