### PR TITLE
Add environment variables for Yandex Cloud settings

### DIFF
--- a/manifests/yandex-cloud-controller-manager.yaml
+++ b/manifests/yandex-cloud-controller-manager.yaml
@@ -62,7 +62,11 @@ spec:
                 secretKeyRef:
                   name: yandex-cloud
                   key: folder-id
+            - name: YANDEX_CLUSTER_NAME
+              value: <CLUSTER_NAME>
             - name: YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID
+              value: <ID>
+            - name: YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID
               value: <ID>
             - name: YANDEX_CLOUD_INTERNAL_NETWORK_IDS
               value: <COMMA_SEPARATED_INTERNAL_NETWORK_IDS>


### PR DESCRIPTION
Add more explicit environment variables to the manifest template.

I encountered some uncertainty when deploying the controller.
After carefully reading the documentation and making a few attempts, it became clear that I needed to add these variables to the manifest