### PR TITLE
fix target group reconciliation

### DIFF
--- a/pkg/cloudprovider/yandex/cloud.go
+++ b/pkg/cloudprovider/yandex/cloud.go
@@ -8,13 +8,13 @@ import (
 	"log"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	v1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/util/workqueue"
 
 	"github.com/deckhouse/yandex-cloud-controller-manager/pkg/yapi"
 
@@ -32,8 +32,10 @@ import (
 )
 
 const (
-	providerName           = "yandex"
-	targetGroupSyncTimeout = 10 * time.Minute
+	providerName              = "yandex"
+	targetGroupSyncKey        = "target-groups"
+	targetGroupSyncMaxRetries = 5
+	targetGroupSyncTimeout    = 10 * time.Minute
 
 	envClusterName        = "YANDEX_CLUSTER_NAME"
 	envRouteTableID       = "YANDEX_CLOUD_ROUTE_TABLE_ID"
@@ -68,10 +70,7 @@ type Cloud struct {
 	nodeTargetGroupSyncer *NodeTargetGroupSyncer
 	config                CloudConfig
 
-	nodeLister             v1.NodeLister
-	targetGroupSyncContext context.Context
-
-	nodeUpdateSyncLock sync.Mutex
+	nodeLister v1.NodeLister
 }
 
 func init() {
@@ -197,31 +196,10 @@ func nodeEligibleForLoadBalancer(node *corev1.Node) bool {
 	return true
 }
 
-func retryTargetGroupSync(ctx context.Context, backoff wait.Backoff, syncFn func(context.Context) error) error {
-	var lastErr error
-	if err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
-		lastErr = syncFn(ctx)
-		return lastErr == nil, nil
-	}); err != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return ctxErr
-		}
-		if lastErr != nil {
-			return lastErr
-		}
-		return err
-	}
-	return nil
-}
-
-func (yc *Cloud) syncTargetGroupsAfterNodeUpdate() {
-	yc.nodeUpdateSyncLock.Lock()
-	defer yc.nodeUpdateSyncLock.Unlock()
-
+func (yc *Cloud) syncTargetGroupsAfterNodeUpdate(ctx context.Context) error {
 	services, err := yc.nodeTargetGroupSyncer.serviceLister.List(labels.Everything())
 	if err != nil {
-		log.Printf("failed to list Services after target group annotation update: %s", err)
-		return
+		return fmt.Errorf("failed to list Services after target group annotation update: %w", err)
 	}
 	activeLoadBalancerExists := false
 	for _, service := range services {
@@ -231,13 +209,12 @@ func (yc *Cloud) syncTargetGroupsAfterNodeUpdate() {
 		}
 	}
 	if !activeLoadBalancerExists {
-		return
+		return nil
 	}
 
 	nodes, err := yc.nodeLister.List(labels.Everything())
 	if err != nil {
-		log.Printf("failed to list Nodes after target group annotation update: %s", err)
-		return
+		return fmt.Errorf("failed to list Nodes after target group annotation update: %w", err)
 	}
 
 	eligibleNodes := make([]*corev1.Node, 0, len(nodes))
@@ -246,25 +223,55 @@ func (yc *Cloud) syncTargetGroupsAfterNodeUpdate() {
 			eligibleNodes = append(eligibleNodes, node)
 		}
 	}
-	backoff := wait.Backoff{Duration: time.Second, Factor: 2, Steps: 5}
-	ctx, cancel := context.WithTimeout(yc.targetGroupSyncContext, targetGroupSyncTimeout)
-	defer cancel()
-	if err := retryTargetGroupSync(ctx, backoff, func(ctx context.Context) error {
-		return yc.nodeTargetGroupSyncer.SyncTGs(ctx, eligibleNodes)
-	}); err != nil {
-		log.Printf("failed to synchronize target groups after Node annotation update: %s", err)
+	return yc.nodeTargetGroupSyncer.SyncTGs(ctx, eligibleNodes)
+}
+
+func processNextTargetGroupSync(
+	ctx context.Context,
+	queue workqueue.TypedRateLimitingInterface[string],
+	syncFn func(context.Context) error,
+) bool {
+	key, shutdown := queue.Get()
+	if shutdown {
+		return false
+	}
+	defer queue.Done(key)
+
+	syncCtx, cancel := context.WithTimeout(ctx, targetGroupSyncTimeout)
+	err := syncFn(syncCtx)
+	cancel()
+
+	if err == nil {
+		queue.Forget(key)
+		return true
+	}
+	if ctx.Err() != nil {
+		queue.Forget(key)
+		return true
+	}
+	if queue.NumRequeues(key) < targetGroupSyncMaxRetries-1 {
+		log.Printf("failed to synchronize target groups after Node annotation update, retrying: %s", err)
+		queue.AddRateLimited(key)
+		return true
+	}
+
+	queue.Forget(key)
+	log.Printf("failed to synchronize target groups after Node annotation update after %d attempts: %s", targetGroupSyncMaxRetries, err)
+	return true
+}
+
+func runTargetGroupSyncWorker(
+	ctx context.Context,
+	queue workqueue.TypedRateLimitingInterface[string],
+	syncFn func(context.Context) error,
+) {
+	for processNextTargetGroupSync(ctx, queue, syncFn) {
 	}
 }
 
 // Initialize passes a Kubernetes clientBuilder interface to the cloud provider
 func (yc *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
 	clientset := clientBuilder.ClientOrDie("cloud-controller-manager")
-	targetGroupSyncContext, cancelTargetGroupSync := context.WithCancel(context.Background())
-	yc.targetGroupSyncContext = targetGroupSyncContext
-	go func() {
-		<-stop
-		cancelTargetGroupSync()
-	}()
 
 	informerFactory := informers.NewSharedInformerFactory(clientset, time.Second*30)
 	serviceInformer := informerFactory.Core().V1().Services()
@@ -287,10 +294,17 @@ func (yc *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder,
 		log.Fatal("Timed out waiting for caches to sync")
 	}
 
+	targetGroupSyncContext := wait.ContextForChannel(stop)
+	targetGroupSyncQueue := workqueue.NewTypedRateLimitingQueue(
+		workqueue.NewTypedItemExponentialFailureRateLimiter[string](time.Second, 8*time.Second),
+	)
+	context.AfterFunc(targetGroupSyncContext, targetGroupSyncQueue.ShutDown)
+	go runTargetGroupSyncWorker(targetGroupSyncContext, targetGroupSyncQueue, yc.syncTargetGroupsAfterNodeUpdate)
+
 	if _, err := nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			if nodeTargetGroupAnnotationChanged(oldObj, newObj) {
-				go yc.syncTargetGroupsAfterNodeUpdate()
+				targetGroupSyncQueue.Add(targetGroupSyncKey)
 			}
 		},
 	}); err != nil {

--- a/pkg/cloudprovider/yandex/cloud.go
+++ b/pkg/cloudprovider/yandex/cloud.go
@@ -1,14 +1,18 @@
 package yandex
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	v1 "k8s.io/client-go/listers/core/v1"
 
 	"github.com/deckhouse/yandex-cloud-controller-manager/pkg/yapi"
@@ -63,6 +67,8 @@ type Cloud struct {
 	config                CloudConfig
 
 	nodeLister v1.NodeLister
+
+	nodeUpdateSyncLock sync.Mutex
 }
 
 func init() {
@@ -166,6 +172,65 @@ func NewCloud(config CloudConfig, api *yapi.YandexCloudAPI) *Cloud {
 	}
 }
 
+func nodeTargetGroupAnnotationChanged(oldObj, newObj interface{}) bool {
+	oldNode, oldOK := oldObj.(*corev1.Node)
+	newNode, newOK := newObj.(*corev1.Node)
+	return oldOK && newOK &&
+		oldNode.Annotations[customTargetGroupNamePrefixAnnotation] != newNode.Annotations[customTargetGroupNamePrefixAnnotation]
+}
+
+func nodeEligibleForLoadBalancer(node *corev1.Node) bool {
+	if !node.DeletionTimestamp.IsZero() {
+		return false
+	}
+	if _, excluded := node.Labels[corev1.LabelNodeExcludeBalancers]; excluded {
+		return false
+	}
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == "ToBeDeletedByClusterAutoscaler" {
+			return false
+		}
+	}
+	return true
+}
+
+func (yc *Cloud) syncTargetGroupsAfterNodeUpdate() {
+	yc.nodeUpdateSyncLock.Lock()
+	defer yc.nodeUpdateSyncLock.Unlock()
+
+	services, err := yc.nodeTargetGroupSyncer.serviceLister.List(labels.Everything())
+	if err != nil {
+		log.Printf("failed to list Services after target group annotation update: %s", err)
+		return
+	}
+	activeLoadBalancerExists := false
+	for _, service := range services {
+		if service.Spec.Type == corev1.ServiceTypeLoadBalancer && service.DeletionTimestamp == nil {
+			activeLoadBalancerExists = true
+			break
+		}
+	}
+	if !activeLoadBalancerExists {
+		return
+	}
+
+	nodes, err := yc.nodeLister.List(labels.Everything())
+	if err != nil {
+		log.Printf("failed to list Nodes after target group annotation update: %s", err)
+		return
+	}
+
+	eligibleNodes := nodes[:0]
+	for _, node := range nodes {
+		if nodeEligibleForLoadBalancer(node) {
+			eligibleNodes = append(eligibleNodes, node)
+		}
+	}
+	if err := yc.nodeTargetGroupSyncer.SyncTGs(context.Background(), eligibleNodes); err != nil {
+		log.Printf("failed to synchronize target groups after Node annotation update: %s", err)
+	}
+}
+
 // Initialize passes a Kubernetes clientBuilder interface to the cloud provider
 func (yc *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
 	clientset := clientBuilder.ClientOrDie("cloud-controller-manager")
@@ -181,7 +246,6 @@ func (yc *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder,
 	}
 
 	yc.nodeLister = nodeInformer.Lister()
-
 	go serviceInformer.Informer().Run(stop)
 	go nodeInformer.Informer().Run(stop)
 
@@ -190,6 +254,16 @@ func (yc *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder,
 	}
 	if !cache.WaitForCacheSync(stop, nodeInformer.Informer().HasSynced) {
 		log.Fatal("Timed out waiting for caches to sync")
+	}
+
+	if _, err := nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			if nodeTargetGroupAnnotationChanged(oldObj, newObj) {
+				go yc.syncTargetGroupsAfterNodeUpdate()
+			}
+		},
+	}); err != nil {
+		log.Fatalf("failed to register Node target group annotation handler: %s", err)
 	}
 }
 

--- a/pkg/cloudprovider/yandex/cloud.go
+++ b/pkg/cloudprovider/yandex/cloud.go
@@ -32,7 +32,8 @@ import (
 )
 
 const (
-	providerName = "yandex"
+	providerName           = "yandex"
+	targetGroupSyncTimeout = 10 * time.Minute
 
 	envClusterName        = "YANDEX_CLUSTER_NAME"
 	envRouteTableID       = "YANDEX_CLOUD_ROUTE_TABLE_ID"
@@ -67,7 +68,8 @@ type Cloud struct {
 	nodeTargetGroupSyncer *NodeTargetGroupSyncer
 	config                CloudConfig
 
-	nodeLister v1.NodeLister
+	nodeLister             v1.NodeLister
+	targetGroupSyncContext context.Context
 
 	nodeUpdateSyncLock sync.Mutex
 }
@@ -195,12 +197,15 @@ func nodeEligibleForLoadBalancer(node *corev1.Node) bool {
 	return true
 }
 
-func retryTargetGroupSync(backoff wait.Backoff, syncFn func() error) error {
+func retryTargetGroupSync(ctx context.Context, backoff wait.Backoff, syncFn func(context.Context) error) error {
 	var lastErr error
-	if err := wait.ExponentialBackoff(backoff, func() (bool, error) {
-		lastErr = syncFn()
+	if err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		lastErr = syncFn(ctx)
 		return lastErr == nil, nil
 	}); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		if lastErr != nil {
 			return lastErr
 		}
@@ -235,15 +240,17 @@ func (yc *Cloud) syncTargetGroupsAfterNodeUpdate() {
 		return
 	}
 
-	eligibleNodes := nodes[:0]
+	eligibleNodes := make([]*corev1.Node, 0, len(nodes))
 	for _, node := range nodes {
 		if nodeEligibleForLoadBalancer(node) {
 			eligibleNodes = append(eligibleNodes, node)
 		}
 	}
 	backoff := wait.Backoff{Duration: time.Second, Factor: 2, Steps: 5}
-	if err := retryTargetGroupSync(backoff, func() error {
-		return yc.nodeTargetGroupSyncer.SyncTGs(context.Background(), eligibleNodes)
+	ctx, cancel := context.WithTimeout(yc.targetGroupSyncContext, targetGroupSyncTimeout)
+	defer cancel()
+	if err := retryTargetGroupSync(ctx, backoff, func(ctx context.Context) error {
+		return yc.nodeTargetGroupSyncer.SyncTGs(ctx, eligibleNodes)
 	}); err != nil {
 		log.Printf("failed to synchronize target groups after Node annotation update: %s", err)
 	}
@@ -252,6 +259,12 @@ func (yc *Cloud) syncTargetGroupsAfterNodeUpdate() {
 // Initialize passes a Kubernetes clientBuilder interface to the cloud provider
 func (yc *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
 	clientset := clientBuilder.ClientOrDie("cloud-controller-manager")
+	targetGroupSyncContext, cancelTargetGroupSync := context.WithCancel(context.Background())
+	yc.targetGroupSyncContext = targetGroupSyncContext
+	go func() {
+		<-stop
+		cancelTargetGroupSync()
+	}()
 
 	informerFactory := informers.NewSharedInformerFactory(clientset, time.Second*30)
 	serviceInformer := informerFactory.Core().V1().Services()

--- a/pkg/cloudprovider/yandex/cloud.go
+++ b/pkg/cloudprovider/yandex/cloud.go
@@ -13,6 +13,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
 	v1 "k8s.io/client-go/listers/core/v1"
 
 	"github.com/deckhouse/yandex-cloud-controller-manager/pkg/yapi"
@@ -194,6 +195,20 @@ func nodeEligibleForLoadBalancer(node *corev1.Node) bool {
 	return true
 }
 
+func retryTargetGroupSync(backoff wait.Backoff, syncFn func() error) error {
+	var lastErr error
+	if err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		lastErr = syncFn()
+		return lastErr == nil, nil
+	}); err != nil {
+		if lastErr != nil {
+			return lastErr
+		}
+		return err
+	}
+	return nil
+}
+
 func (yc *Cloud) syncTargetGroupsAfterNodeUpdate() {
 	yc.nodeUpdateSyncLock.Lock()
 	defer yc.nodeUpdateSyncLock.Unlock()
@@ -226,7 +241,10 @@ func (yc *Cloud) syncTargetGroupsAfterNodeUpdate() {
 			eligibleNodes = append(eligibleNodes, node)
 		}
 	}
-	if err := yc.nodeTargetGroupSyncer.SyncTGs(context.Background(), eligibleNodes); err != nil {
+	backoff := wait.Backoff{Duration: time.Second, Factor: 2, Steps: 5}
+	if err := retryTargetGroupSync(backoff, func() error {
+		return yc.nodeTargetGroupSyncer.SyncTGs(context.Background(), eligibleNodes)
+	}); err != nil {
 		log.Printf("failed to synchronize target groups after Node annotation update: %s", err)
 	}
 }

--- a/pkg/cloudprovider/yandex/load_balancer_tg_controller.go
+++ b/pkg/cloudprovider/yandex/load_balancer_tg_controller.go
@@ -67,9 +67,14 @@ func (ntgs *NodeTargetGroupSyncer) SyncTGs(ctx context.Context, nodes []*corev1.
 
 type tgNameToTargetMap map[string][]*loadbalancer.Target
 
-func fromNodeToInterfaceSlice(nodes []*corev1.Node) (ret []interface{}) {
+func nodeTargetGroupSyncState(nodes []*corev1.Node) (ret []interface{}) {
 	for _, node := range nodes {
-		ret = append(ret, node.Name)
+		ret = append(ret, fmt.Sprintf(
+			"%s\x00%s\x00%s",
+			node.Name,
+			node.Spec.ProviderID,
+			node.Annotations[customTargetGroupNamePrefixAnnotation],
+		))
 	}
 
 	return
@@ -109,7 +114,7 @@ func (ntgs *NodeTargetGroupSyncer) synchronizeNodesWithTargetGroups(ctx context.
 		return nil
 	}
 
-	newSet := mapset.NewSetFromSlice(fromNodeToInterfaceSlice(nodes))
+	newSet := mapset.NewSetFromSlice(nodeTargetGroupSyncState(nodes))
 	if ntgs.lastVisitedNodes.Equal(newSet) {
 		return nil
 	}
@@ -141,11 +146,8 @@ func (ntgs *NodeTargetGroupSyncer) synchronizeNodesWithTargetGroups(ctx context.
 		return fmt.Errorf("failed to construct tgNameToTargetMap: %s", err)
 	}
 
-	for tgName, targets := range mapping {
-		_, err := ntgs.cloud.yandexService.LbSvc.CreateOrUpdateTG(ctx, tgName, targets)
-		if err != nil {
-			return err
-		}
+	if err := ntgs.cloud.yandexService.LbSvc.ReconcileTargetGroups(ctx, ntgs.cloud.config.ClusterName, mapping); err != nil {
+		return err
 	}
 
 	ntgs.lastVisitedNodes = newSet

--- a/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
+++ b/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
@@ -29,3 +29,41 @@ func TestNodeTargetGroupSyncState(t *testing.T) {
 		t.Fatal("provider ID change must invalidate the node sync state")
 	}
 }
+
+func TestNodeTargetGroupAnnotationChanged(t *testing.T) {
+	oldNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:        "node-1",
+		Annotations: map[string]string{customTargetGroupNamePrefixAnnotation: "frontend"},
+	}}
+
+	unrelatedUpdate := oldNode.DeepCopy()
+	unrelatedUpdate.Labels = map[string]string{"example.com/test": "value"}
+	if nodeTargetGroupAnnotationChanged(oldNode, unrelatedUpdate) {
+		t.Fatal("unrelated Node update must not trigger target group synchronization")
+	}
+
+	annotationUpdate := oldNode.DeepCopy()
+	delete(annotationUpdate.Annotations, customTargetGroupNamePrefixAnnotation)
+	if !nodeTargetGroupAnnotationChanged(oldNode, annotationUpdate) {
+		t.Fatal("target group annotation update must trigger synchronization")
+	}
+}
+
+func TestNodeEligibleForLoadBalancer(t *testing.T) {
+	eligible := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "eligible"}}
+	if !nodeEligibleForLoadBalancer(eligible) {
+		t.Fatal("ordinary Node must be eligible")
+	}
+
+	excluded := eligible.DeepCopy()
+	excluded.Labels = map[string]string{corev1.LabelNodeExcludeBalancers: "true"}
+	if nodeEligibleForLoadBalancer(excluded) {
+		t.Fatal("Node excluded from external load balancers must not be eligible")
+	}
+
+	tainted := eligible.DeepCopy()
+	tainted.Spec.Taints = []corev1.Taint{{Key: "ToBeDeletedByClusterAutoscaler"}}
+	if nodeEligibleForLoadBalancer(tainted) {
+		t.Fatal("Node marked for deletion by cluster autoscaler must not be eligible")
+	}
+}

--- a/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
+++ b/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
@@ -1,6 +1,7 @@
 package yandex
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -73,7 +74,7 @@ func TestNodeEligibleForLoadBalancer(t *testing.T) {
 
 func TestRetryTargetGroupSync(t *testing.T) {
 	attempts := 0
-	err := retryTargetGroupSync(wait.Backoff{Duration: time.Millisecond, Steps: 3}, func() error {
+	err := retryTargetGroupSync(context.Background(), wait.Backoff{Duration: time.Millisecond, Steps: 3}, func(context.Context) error {
 		attempts++
 		if attempts < 3 {
 			return errors.New("temporary error")
@@ -85,5 +86,21 @@ func TestRetryTargetGroupSync(t *testing.T) {
 	}
 	if attempts != 3 {
 		t.Fatalf("sync attempts = %d, want 3", attempts)
+	}
+}
+
+func TestRetryTargetGroupSyncCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	attempts := 0
+	err := retryTargetGroupSync(ctx, wait.Backoff{Duration: time.Hour, Steps: 3}, func(context.Context) error {
+		attempts++
+		cancel()
+		return errors.New("temporary error")
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("retry target group sync error = %v, want context.Canceled", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("sync attempts = %d, want 1", attempts)
 	}
 }

--- a/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
+++ b/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
@@ -1,0 +1,31 @@
+package yandex
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mapset "github.com/deckarep/golang-set"
+)
+
+func TestNodeTargetGroupSyncState(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+		Spec:       corev1.NodeSpec{ProviderID: "yandex://instance-1"},
+	}
+
+	initial := mapset.NewSetFromSlice(nodeTargetGroupSyncState([]*corev1.Node{node}))
+
+	node.Annotations = map[string]string{customTargetGroupNamePrefixAnnotation: "frontend"}
+	withAnnotation := mapset.NewSetFromSlice(nodeTargetGroupSyncState([]*corev1.Node{node}))
+	if initial.Equal(withAnnotation) {
+		t.Fatal("target group annotation change must invalidate the node sync state")
+	}
+
+	node.Spec.ProviderID = "yandex://instance-2"
+	withNewProviderID := mapset.NewSetFromSlice(nodeTargetGroupSyncState([]*corev1.Node{node}))
+	if withAnnotation.Equal(withNewProviderID) {
+		t.Fatal("provider ID change must invalidate the node sync state")
+	}
+}

--- a/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
+++ b/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
@@ -8,7 +8,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
 
 	mapset "github.com/deckarep/golang-set"
 )
@@ -72,35 +72,93 @@ func TestNodeEligibleForLoadBalancer(t *testing.T) {
 	}
 }
 
-func TestRetryTargetGroupSync(t *testing.T) {
+func newTestTargetGroupSyncQueue() workqueue.TypedRateLimitingInterface[string] {
+	return workqueue.NewTypedRateLimitingQueue(
+		workqueue.NewTypedItemExponentialFailureRateLimiter[string](time.Nanosecond, time.Nanosecond),
+	)
+}
+
+func TestTargetGroupSyncWorkerRetriesUntilSuccess(t *testing.T) {
+	queue := newTestTargetGroupSyncQueue()
+	queue.Add(targetGroupSyncKey)
+
 	attempts := 0
-	err := retryTargetGroupSync(context.Background(), wait.Backoff{Duration: time.Millisecond, Steps: 3}, func(context.Context) error {
+	runTargetGroupSyncWorker(context.Background(), queue, func(context.Context) error {
 		attempts++
 		if attempts < 3 {
 			return errors.New("temporary error")
 		}
+		queue.ShutDown()
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("retry target group sync: %v", err)
-	}
+
 	if attempts != 3 {
 		t.Fatalf("sync attempts = %d, want 3", attempts)
 	}
 }
 
-func TestRetryTargetGroupSyncCancellation(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+func TestTargetGroupSyncWorkerCoalescesEvents(t *testing.T) {
+	queue := newTestTargetGroupSyncQueue()
+	queue.Add(targetGroupSyncKey)
+
 	attempts := 0
-	err := retryTargetGroupSync(ctx, wait.Backoff{Duration: time.Hour, Steps: 3}, func(context.Context) error {
+	runTargetGroupSyncWorker(context.Background(), queue, func(context.Context) error {
 		attempts++
-		cancel()
-		return errors.New("temporary error")
+		if attempts == 1 {
+			for i := 0; i < 10; i++ {
+				queue.Add(targetGroupSyncKey)
+			}
+			return nil
+		}
+		queue.ShutDown()
+		return nil
 	})
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("retry target group sync error = %v, want context.Canceled", err)
+
+	if attempts != 2 {
+		t.Fatalf("sync attempts = %d, want 2", attempts)
 	}
-	if attempts != 1 {
-		t.Fatalf("sync attempts = %d, want 1", attempts)
+}
+
+func TestTargetGroupSyncWorkerStopsAfterMaxRetries(t *testing.T) {
+	queue := newTestTargetGroupSyncQueue()
+	queue.Add(targetGroupSyncKey)
+
+	attempts := 0
+	runTargetGroupSyncWorker(context.Background(), queue, func(context.Context) error {
+		attempts++
+		if attempts == targetGroupSyncMaxRetries {
+			queue.ShutDown()
+		}
+		return errors.New("persistent error")
+	})
+
+	if attempts != targetGroupSyncMaxRetries {
+		t.Fatalf("sync attempts = %d, want %d", attempts, targetGroupSyncMaxRetries)
+	}
+}
+
+func TestTargetGroupSyncWorkerStopsOnContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	queue := newTestTargetGroupSyncQueue()
+	context.AfterFunc(ctx, queue.ShutDown)
+	queue.Add(targetGroupSyncKey)
+
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runTargetGroupSyncWorker(ctx, queue, func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	}()
+
+	<-started
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("target group sync worker did not stop after context cancellation")
 	}
 }

--- a/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
+++ b/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
@@ -1,10 +1,13 @@
 package yandex
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	mapset "github.com/deckarep/golang-set"
 )
@@ -65,5 +68,22 @@ func TestNodeEligibleForLoadBalancer(t *testing.T) {
 	tainted.Spec.Taints = []corev1.Taint{{Key: "ToBeDeletedByClusterAutoscaler"}}
 	if nodeEligibleForLoadBalancer(tainted) {
 		t.Fatal("Node marked for deletion by cluster autoscaler must not be eligible")
+	}
+}
+
+func TestRetryTargetGroupSync(t *testing.T) {
+	attempts := 0
+	err := retryTargetGroupSync(wait.Backoff{Duration: time.Millisecond, Steps: 3}, func() error {
+		attempts++
+		if attempts < 3 {
+			return errors.New("temporary error")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("retry target group sync: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("sync attempts = %d, want 3", attempts)
 	}
 }

--- a/pkg/yapi/loadbalancer.go
+++ b/pkg/yapi/loadbalancer.go
@@ -314,6 +314,44 @@ func (ySvc *LoadBalancerService) CreateOrUpdateTG(ctx context.Context, tgName st
 	return tg.Id, nil
 }
 
+// ReconcileTargetGroups synchronizes all target groups owned by the cluster.
+// Targets are removed from their old groups before they are added to new ones,
+// because Yandex Cloud does not allow a target to belong to multiple groups.
+func (ySvc *LoadBalancerService) ReconcileTargetGroups(ctx context.Context, clusterName string, expected map[string][]*loadbalancer.Target) error {
+	targetGroups, err := ySvc.GetTGsByClusterName(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	for _, targetGroup := range targetGroups {
+		_, targetsToRemove := diffTargetGroupTargets(expected[targetGroup.Name], targetGroup.Targets)
+		if len(targetsToRemove) == 0 {
+			continue
+		}
+
+		req := &loadbalancer.RemoveTargetsRequest{
+			TargetGroupId: targetGroup.Id,
+			Targets:       targetsToRemove,
+		}
+		log.Printf("Removing Targets: %s", req.String())
+
+		_, _, err = ySvc.cloudCtx.OperationWaiter(ctx, func() (*operation.Operation, error) {
+			return ySvc.TgSvc.RemoveTargets(ctx, req)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	for targetGroupName, targets := range expected {
+		if _, err := ySvc.CreateOrUpdateTG(ctx, targetGroupName, targets); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (ySvc *LoadBalancerService) RemoveTGByID(ctx context.Context, tgId string) error {
 	tgDeleteRequest := &loadbalancer.DeleteTargetGroupRequest{
 		TargetGroupId: tgId,

--- a/pkg/yapi/loadbalancer_test.go
+++ b/pkg/yapi/loadbalancer_test.go
@@ -1,0 +1,115 @@
+package yapi
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	loadbalancer "github.com/yandex-cloud/go-genproto/yandex/cloud/loadbalancer/v1"
+	cloudoperation "github.com/yandex-cloud/go-genproto/yandex/cloud/operation"
+	sdkoperation "github.com/yandex-cloud/go-sdk/operation"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+)
+
+type fakeTargetGroupClient struct {
+	loadbalancer.TargetGroupServiceClient
+
+	targetGroups map[string]*loadbalancer.TargetGroup
+	operations   []string
+}
+
+func (f *fakeTargetGroupClient) List(_ context.Context, request *loadbalancer.ListTargetGroupsRequest, _ ...grpc.CallOption) (*loadbalancer.ListTargetGroupsResponse, error) {
+	response := &loadbalancer.ListTargetGroupsResponse{}
+	for _, targetGroup := range f.targetGroups {
+		if request.Filter == "" || request.Filter == fmt.Sprintf("name = %q", targetGroup.Name) {
+			response.TargetGroups = append(response.TargetGroups, targetGroup)
+		}
+	}
+	return response, nil
+}
+
+func (f *fakeTargetGroupClient) RemoveTargets(_ context.Context, request *loadbalancer.RemoveTargetsRequest, _ ...grpc.CallOption) (*cloudoperation.Operation, error) {
+	targetGroup := f.targetGroupByID(request.TargetGroupId)
+	remainingTargets := make([]*loadbalancer.Target, 0, len(targetGroup.Targets))
+	for _, actualTarget := range targetGroup.Targets {
+		shouldRemove := false
+		for _, targetToRemove := range request.Targets {
+			if actualTarget.SubnetId == targetToRemove.SubnetId && actualTarget.Address == targetToRemove.Address {
+				shouldRemove = true
+				break
+			}
+		}
+		if !shouldRemove {
+			remainingTargets = append(remainingTargets, actualTarget)
+		}
+	}
+	targetGroup.Targets = remainingTargets
+	f.operations = append(f.operations, "remove:"+targetGroup.Name)
+	return &cloudoperation.Operation{}, nil
+}
+
+func (f *fakeTargetGroupClient) AddTargets(_ context.Context, request *loadbalancer.AddTargetsRequest, _ ...grpc.CallOption) (*cloudoperation.Operation, error) {
+	targetGroup := f.targetGroupByID(request.TargetGroupId)
+	for _, otherTargetGroup := range f.targetGroups {
+		if otherTargetGroup.Id == targetGroup.Id {
+			continue
+		}
+		conflictingTargets, _ := diffTargetGroupTargets(request.Targets, otherTargetGroup.Targets)
+		if len(conflictingTargets) != len(request.Targets) {
+			return nil, fmt.Errorf("target already belongs to %s", otherTargetGroup.Name)
+		}
+	}
+
+	targetGroup.Targets = append(targetGroup.Targets, request.Targets...)
+	f.operations = append(f.operations, "add:"+targetGroup.Name)
+	return &cloudoperation.Operation{}, nil
+}
+
+func (f *fakeTargetGroupClient) targetGroupByID(id string) *loadbalancer.TargetGroup {
+	for _, targetGroup := range f.targetGroups {
+		if targetGroup.Id == id {
+			return targetGroup
+		}
+	}
+	return nil
+}
+
+func TestReconcileTargetGroupsMovesTargetsBetweenGroups(t *testing.T) {
+	const (
+		clusterName = "cluster"
+		defaultTG   = "cluster-network"
+		customTG    = "frontendcluster-network"
+	)
+	target := &loadbalancer.Target{SubnetId: "subnet", Address: "10.0.0.1"}
+	fakeClient := &fakeTargetGroupClient{targetGroups: map[string]*loadbalancer.TargetGroup{
+		defaultTG: {Id: "default-id", Name: defaultTG},
+		customTG:  {Id: "custom-id", Name: customTG, Targets: []*loadbalancer.Target{target}},
+	}}
+	service := NewLoadBalancerService(nil, fakeClient, &CloudContext{
+		FolderID: "folder",
+		OperationWaiter: func(_ context.Context, operation func() (*cloudoperation.Operation, error)) (proto.Message, *sdkoperation.Operation, error) {
+			_, err := operation()
+			return nil, nil, err
+		},
+	})
+
+	err := service.ReconcileTargetGroups(context.Background(), clusterName, map[string][]*loadbalancer.Target{
+		defaultTG: {target},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantOperations := []string{"remove:" + customTG, "add:" + defaultTG}
+	if !reflect.DeepEqual(fakeClient.operations, wantOperations) {
+		t.Fatalf("unexpected operation order: got %v, want %v", fakeClient.operations, wantOperations)
+	}
+	if len(fakeClient.targetGroups[customTG].Targets) != 0 {
+		t.Fatalf("custom target group still has targets: %v", fakeClient.targetGroups[customTG].Targets)
+	}
+	if !reflect.DeepEqual(fakeClient.targetGroups[defaultTG].Targets, []*loadbalancer.Target{target}) {
+		t.Fatalf("default target group has unexpected targets: %v", fakeClient.targetGroups[defaultTG].Targets)
+	}
+}


### PR DESCRIPTION
Invalidate the node target group cache when relevant node state changes and move targets between groups in remove-before-add order.