### PR TITLE
fix target group sync with empty node provider IDs

### DIFF
--- a/pkg/cloudprovider/yandex/cloud.go
+++ b/pkg/cloudprovider/yandex/cloud.go
@@ -281,7 +281,6 @@ func (yc *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder,
 		cloud:            yc,
 		serviceLister:    serviceInformer.Lister(),
 		lastVisitedNodes: mapset.NewSet(),
-		lastSkippedNodes: mapset.NewSet(),
 	}
 
 	yc.nodeLister = nodeInformer.Lister()

--- a/pkg/cloudprovider/yandex/cloud.go
+++ b/pkg/cloudprovider/yandex/cloud.go
@@ -281,6 +281,7 @@ func (yc *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder,
 		cloud:            yc,
 		serviceLister:    serviceInformer.Lister(),
 		lastVisitedNodes: mapset.NewSet(),
+		lastSkippedNodes: mapset.NewSet(),
 	}
 
 	yc.nodeLister = nodeInformer.Lister()

--- a/pkg/cloudprovider/yandex/instances_test.go
+++ b/pkg/cloudprovider/yandex/instances_test.go
@@ -60,17 +60,3 @@ func TestGetInstanceByProviderIDReturnsInstanceNotFoundForMissingInstance(t *tes
 		t.Fatalf("expected cloudprovider.InstanceNotFound for a deleted Instance, got %v", err)
 	}
 }
-
-// A ProviderID that cannot be parsed must not be reported as a missing Instance: skipping such a
-// Node would hide a misconfiguration, so it has to surface as an ordinary error instead.
-func TestGetInstanceByProviderIDRejectsUnparsableProviderID(t *testing.T) {
-	cloud := newTestCloud(nil)
-
-	_, err := cloud.getInstanceByProviderID(context.Background(), "aws:///eu-central-1a/i-1")
-	if err == nil {
-		t.Fatal("expected an error for a non-Yandex ProviderID")
-	}
-	if errors.Is(err, cloudprovider.InstanceNotFound) {
-		t.Fatalf("an unparsable ProviderID must not be reported as a missing Instance, got %v", err)
-	}
-}

--- a/pkg/cloudprovider/yandex/instances_test.go
+++ b/pkg/cloudprovider/yandex/instances_test.go
@@ -1,0 +1,76 @@
+package yandex
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+	compute "github.com/yandex-cloud/go-genproto/yandex/cloud/compute/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	cloudprovider "k8s.io/cloud-provider"
+
+	"github.com/deckhouse/yandex-cloud-controller-manager/pkg/yapi"
+)
+
+type fakeInstanceServiceClient struct {
+	compute.InstanceServiceClient
+
+	instances map[string]*compute.Instance
+}
+
+func (f *fakeInstanceServiceClient) Get(_ context.Context, request *compute.GetInstanceRequest, _ ...grpc.CallOption) (*compute.Instance, error) {
+	instance, found := f.instances[request.InstanceId]
+	if !found {
+		return nil, status.Error(codes.NotFound, "instance not found")
+	}
+	return instance, nil
+}
+
+func newTestCloud(instances map[string]*compute.Instance) *Cloud {
+	cloudCtx := &yapi.CloudContext{FolderID: "test-folder"}
+	return &Cloud{
+		config: CloudConfig{FolderID: "test-folder"},
+		yandexService: &yapi.YandexCloudAPI{
+			ComputeSvc: yapi.NewComputeService(&fakeInstanceServiceClient{instances: instances}, nil, cloudCtx),
+		},
+	}
+}
+
+// Target group synchronization leaves a Node out of the target groups when its Instance is gone,
+// and that decision is made by matching cloudprovider.InstanceNotFound. Should this stop being a
+// typed error, a single deleted Instance would silently start aborting synchronization for the
+// whole cluster again.
+func TestGetInstanceByProviderIDReturnsInstanceNotFoundForMissingInstance(t *testing.T) {
+	cloud := newTestCloud(map[string]*compute.Instance{
+		"instance-1": {Id: "instance-1", Name: "node-1"},
+	})
+
+	instance, err := cloud.getInstanceByProviderID(context.Background(), "yandex://instance-1")
+	if err != nil {
+		t.Fatalf("expected an existing Instance to resolve, got error: %v", err)
+	}
+	if instance.Id != "instance-1" {
+		t.Fatalf("resolved Instance ID = %q, want %q", instance.Id, "instance-1")
+	}
+
+	_, err = cloud.getInstanceByProviderID(context.Background(), "yandex://instance-2")
+	if !errors.Is(err, cloudprovider.InstanceNotFound) {
+		t.Fatalf("expected cloudprovider.InstanceNotFound for a deleted Instance, got %v", err)
+	}
+}
+
+// A ProviderID that cannot be parsed must not be reported as a missing Instance: skipping such a
+// Node would hide a misconfiguration, so it has to surface as an ordinary error instead.
+func TestGetInstanceByProviderIDRejectsUnparsableProviderID(t *testing.T) {
+	cloud := newTestCloud(nil)
+
+	_, err := cloud.getInstanceByProviderID(context.Background(), "aws:///eu-central-1a/i-1")
+	if err == nil {
+		t.Fatal("expected an error for a non-Yandex ProviderID")
+	}
+	if errors.Is(err, cloudprovider.InstanceNotFound) {
+		t.Fatalf("an unparsable ProviderID must not be reported as a missing Instance, got %v", err)
+	}
+}

--- a/pkg/cloudprovider/yandex/load_balancer.go
+++ b/pkg/cloudprovider/yandex/load_balancer.go
@@ -223,7 +223,13 @@ func (yc *Cloud) ensureLB(ctx context.Context, service *v1.Service, nodes []*v1.
 		return nil, err
 	}
 	if tg == nil {
-		return nil, fmt.Errorf("TG %q does not exist yet; it is only created for Nodes carrying a Yandex ProviderID, check that the Nodes backing this Service have one", tgName)
+		// Two things keep this target group from existing: no Node carries a Yandex ProviderID, or
+		// the prefix annotation on this Service names a target group that no Node asks for – the
+		// name is built from the Service annotation here, but from the Node annotation in
+		// constructTgNameToTargetMap, and a Service annotated ahead of its Nodes is a normal
+		// transient state.
+		return nil, fmt.Errorf("TG %q does not exist yet: target groups are built from Nodes carrying a Yandex ProviderID, and the %s annotation on this Service must match the one on those Nodes",
+			tgName, customTargetGroupNamePrefixAnnotation)
 	}
 
 	externalIP, err := yc.yandexService.LbSvc.CreateOrUpdateLB(ctx, lbName, listenerSpecs, []*loadbalancer.AttachedTargetGroup{

--- a/pkg/cloudprovider/yandex/load_balancer.go
+++ b/pkg/cloudprovider/yandex/load_balancer.go
@@ -223,7 +223,7 @@ func (yc *Cloud) ensureLB(ctx context.Context, service *v1.Service, nodes []*v1.
 		return nil, err
 	}
 	if tg == nil {
-		return nil, fmt.Errorf("TG %q does not exist yet", tgName)
+		return nil, fmt.Errorf("TG %q does not exist yet; it is only created for Nodes carrying a Yandex ProviderID, check that the Nodes backing this Service have one", tgName)
 	}
 
 	externalIP, err := yc.yandexService.LbSvc.CreateOrUpdateLB(ctx, lbName, listenerSpecs, []*loadbalancer.AttachedTargetGroup{

--- a/pkg/cloudprovider/yandex/load_balancer_tg_controller.go
+++ b/pkg/cloudprovider/yandex/load_balancer_tg_controller.go
@@ -16,7 +16,7 @@ import (
 	"github.com/yandex-cloud/go-genproto/yandex/cloud/loadbalancer/v1"
 	"github.com/yandex-cloud/go-genproto/yandex/cloud/vpc/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
+	cloudprovider "k8s.io/cloud-provider"
 
 	corev1listers "k8s.io/client-go/listers/core/v1"
 
@@ -30,6 +30,7 @@ type NodeTargetGroupSyncer struct {
 	cloud *Cloud
 
 	lastVisitedNodes mapset.Set
+	lastSkippedNodes mapset.Set
 	serviceLister    corev1listers.ServiceLister
 
 	tgSyncLock sync.Mutex
@@ -126,9 +127,9 @@ func partitionNodesByProviderID(nodes []*corev1.Node) (yandexNodes []*corev1.Nod
 			continue
 		}
 
-		// ParseProviderID anchors on the yandex:// scheme. A substring match would also accept a
-		// foreign ProviderID that merely happens to mention the provider name, and since the
-		// Instance is then looked up by Node name, that could attach an unrelated VM to the TG.
+		// ParseProviderID anchors on the yandex:// scheme, unlike a substring match, which would
+		// also accept a foreign ProviderID that merely mentions the provider name. Its result is
+		// what the Instance lookup consumes, so an unparsable value has to be rejected here.
 		if _, _, err := ParseProviderID(node.Spec.ProviderID); err != nil {
 			skipped = append(skipped, fmt.Sprintf("%s (%s)", node.Name, err))
 			continue
@@ -140,6 +141,27 @@ func partitionNodesByProviderID(nodes []*corev1.Node) (yandexNodes []*corev1.Nod
 	return yandexNodes, skipped
 }
 
+// skippedNodesChanged records the Nodes left out of the target groups and reports whether that set
+// differs from the previous synchronization. Skipped Nodes have to be visible at default verbosity
+// – an operator must be able to see that a Node dropped out of the target groups – but a cluster
+// with static Nodes would otherwise repeat the same warning on every synchronization forever.
+//
+// Node order from the informer is not stable, so this compares sets rather than slices, and a nil
+// lastSkippedNodes counts as changed so the first observation is always reported.
+func (ntgs *NodeTargetGroupSyncer) skippedNodesChanged(skipped []string) bool {
+	current := mapset.NewSet()
+	for _, reason := range skipped {
+		current.Add(reason)
+	}
+
+	if ntgs.lastSkippedNodes != nil && ntgs.lastSkippedNodes.Equal(current) {
+		return false
+	}
+	ntgs.lastSkippedNodes = current
+
+	return true
+}
+
 func (ntgs *NodeTargetGroupSyncer) synchronizeNodesWithTargetGroups(ctx context.Context, nodes []*corev1.Node) error {
 	if len(nodes) == 0 {
 		klog.Info("no nodes to synchronize TGs with, skipping...")
@@ -147,17 +169,17 @@ func (ntgs *NodeTargetGroupSyncer) synchronizeNodesWithTargetGroups(ctx context.
 	}
 
 	yandexNodes, skippedNodes := partitionNodesByProviderID(nodes)
-	if len(yandexNodes) == 0 {
-		klog.Warningf("none of %d Nodes have a valid Yandex ProviderID, skipping TG synchronization: %s",
-			len(nodes), strings.Join(skippedNodes, "; "))
-		return nil
+
+	// Reported before the lastVisitedNodes check below: a skipped Node never reaches that cache,
+	// so gating this on a changed Node set would hide it entirely.
+	if ntgs.skippedNodesChanged(skippedNodes) && len(skippedNodes) > 0 {
+		klog.Warningf("skipping %d of %d Nodes during TG synchronization: %s",
+			len(skippedNodes), len(nodes), strings.Join(skippedNodes, "; "))
 	}
 
-	// Reported before the cache check below: a Node being skipped is not reflected in
-	// lastVisitedNodes, so gating this on a changed Node set would hide it entirely.
-	if len(skippedNodes) > 0 {
-		klog.V(4).Infof("skipping %d of %d Nodes during TG synchronization: %s",
-			len(skippedNodes), len(nodes), strings.Join(skippedNodes, "; "))
+	if len(yandexNodes) == 0 {
+		klog.Warningf("none of %d Nodes have a valid Yandex ProviderID, skipping TG synchronization", len(nodes))
+		return nil
 	}
 
 	newSet := mapset.NewSetFromSlice(nodeTargetGroupSyncState(yandexNodes))
@@ -165,14 +187,22 @@ func (ntgs *NodeTargetGroupSyncer) synchronizeNodesWithTargetGroups(ctx context.
 		return nil
 	}
 
-	// TODO: speed up by not performing individual lookups
 	var instances []*instanceWithNodeInfo
 	for _, node := range yandexNodes {
-		nodeName := MapNodeNameToInstanceName(types.NodeName(node.Name))
-		log.Printf("Finding Instance by Folder %q and Name %q", ntgs.cloud.config.FolderID, nodeName)
-		instance, err := ntgs.cloud.yandexService.ComputeSvc.FindInstanceByName(ctx, nodeName)
-		if err != nil || instance == nil {
-			return fmt.Errorf("failed to find Instance by its name: %s", err)
+		// getInstanceByProviderID resolves a modern yandex://<id> ProviderID with a single Get by
+		// ID instead of listing the folder by Node name, which also means a Node is never matched
+		// to an unrelated Instance that happens to share its name.
+		instance, err := ntgs.cloud.getInstanceByProviderID(ctx, node.Spec.ProviderID)
+		if err != nil {
+			// A deleted Instance must not abort synchronization for every other Node, the same way
+			// an empty ProviderID must not. Network and server-side failures still do. The state is
+			// self-clearing: cloud-node-lifecycle removes Nodes whose Instance no longer exists.
+			if errors.Is(err, cloudprovider.InstanceNotFound) {
+				klog.Warningf("Instance for Node %s (%s) no longer exists, leaving it out of the target groups",
+					node.Name, node.Spec.ProviderID)
+				continue
+			}
+			return fmt.Errorf("failed to find Instance for Node %s: %w", node.Name, err)
 		}
 
 		instances = append(instances, &instanceWithNodeInfo{Instance: instance, Node: node})
@@ -187,7 +217,14 @@ func (ntgs *NodeTargetGroupSyncer) synchronizeNodesWithTargetGroups(ctx context.
 		return err
 	}
 
-	ntgs.lastVisitedNodes = newSet
+	// The set that was achieved, not the one that was desired: a Node left out because its Instance
+	// is gone has to be retried on the next synchronization rather than pinned until an unrelated
+	// change makes the desired set differ again.
+	syncedNodes := make([]*corev1.Node, 0, len(instances))
+	for _, instance := range instances {
+		syncedNodes = append(syncedNodes, instance.Node)
+	}
+	ntgs.lastVisitedNodes = mapset.NewSetFromSlice(nodeTargetGroupSyncState(syncedNodes))
 
 	return nil
 }

--- a/pkg/cloudprovider/yandex/load_balancer_tg_controller.go
+++ b/pkg/cloudprovider/yandex/load_balancer_tg_controller.go
@@ -108,40 +108,66 @@ type instanceWithNodeInfo struct {
 	Node     *corev1.Node
 }
 
+// partitionNodesByProviderID splits Nodes into the ones that can be placed into a target group
+// and human-readable reasons for the ones that cannot. Nodes without a ProviderID are not an
+// error: a freshly registered Node has no ProviderID until the node controller assigns one, and
+// a cluster may legitimately mix cloud Nodes with static ones that never get a Yandex ProviderID.
+//
+// This is a different notion of eligibility from nodeEligibleForLoadBalancer, which filters on
+// Node state – deletion, exclusion label, autoscaler taint – rather than on the ProviderID.
+//
+// Filtering is silent: callers decide what to report, so that a steady-state cluster does not
+// repeat the same per-Node messages at default verbosity on every synchronization.
+func partitionNodesByProviderID(nodes []*corev1.Node) (yandexNodes []*corev1.Node, skipped []string) {
+	yandexNodes = make([]*corev1.Node, 0, len(nodes))
+	for _, node := range nodes {
+		if node.Spec.ProviderID == "" {
+			skipped = append(skipped, fmt.Sprintf("%s (ProviderID is empty)", node.Name))
+			continue
+		}
+
+		// ParseProviderID anchors on the yandex:// scheme. A substring match would also accept a
+		// foreign ProviderID that merely happens to mention the provider name, and since the
+		// Instance is then looked up by Node name, that could attach an unrelated VM to the TG.
+		if _, _, err := ParseProviderID(node.Spec.ProviderID); err != nil {
+			skipped = append(skipped, fmt.Sprintf("%s (%s)", node.Name, err))
+			continue
+		}
+
+		yandexNodes = append(yandexNodes, node)
+	}
+
+	return yandexNodes, skipped
+}
+
 func (ntgs *NodeTargetGroupSyncer) synchronizeNodesWithTargetGroups(ctx context.Context, nodes []*corev1.Node) error {
 	if len(nodes) == 0 {
 		klog.Info("no nodes to synchronize TGs with, skipping...")
 		return nil
 	}
 
-	eligibleNodes := make([]*corev1.Node, 0, len(nodes))
-	for _, node := range nodes {
-		if node.Spec.ProviderID == "" {
-			klog.Warningf("node %s ProviderID is empty, skipping target group synchronization for this node", node.Name)
-			continue
-		}
-
-		if !strings.Contains(node.Spec.ProviderID, "yandex") {
-			log.Printf("node %s ProviderID is not yandex (%s), skipping", node.Name, node.Spec.ProviderID)
-			continue
-		}
-
-		eligibleNodes = append(eligibleNodes, node)
-	}
-
-	if len(eligibleNodes) == 0 {
-		klog.Warning("no nodes with valid Yandex ProviderID to synchronize TGs with, skipping...")
+	yandexNodes, skippedNodes := partitionNodesByProviderID(nodes)
+	if len(yandexNodes) == 0 {
+		klog.Warningf("none of %d Nodes have a valid Yandex ProviderID, skipping TG synchronization: %s",
+			len(nodes), strings.Join(skippedNodes, "; "))
 		return nil
 	}
 
-	newSet := mapset.NewSetFromSlice(nodeTargetGroupSyncState(eligibleNodes))
+	// Reported before the cache check below: a Node being skipped is not reflected in
+	// lastVisitedNodes, so gating this on a changed Node set would hide it entirely.
+	if len(skippedNodes) > 0 {
+		klog.V(4).Infof("skipping %d of %d Nodes during TG synchronization: %s",
+			len(skippedNodes), len(nodes), strings.Join(skippedNodes, "; "))
+	}
+
+	newSet := mapset.NewSetFromSlice(nodeTargetGroupSyncState(yandexNodes))
 	if ntgs.lastVisitedNodes.Equal(newSet) {
 		return nil
 	}
 
 	// TODO: speed up by not performing individual lookups
 	var instances []*instanceWithNodeInfo
-	for _, node := range eligibleNodes {
+	for _, node := range yandexNodes {
 		nodeName := MapNodeNameToInstanceName(types.NodeName(node.Name))
 		log.Printf("Finding Instance by Folder %q and Name %q", ntgs.cloud.config.FolderID, nodeName)
 		instance, err := ntgs.cloud.yandexService.ComputeSvc.FindInstanceByName(ctx, nodeName)

--- a/pkg/cloudprovider/yandex/load_balancer_tg_controller.go
+++ b/pkg/cloudprovider/yandex/load_balancer_tg_controller.go
@@ -114,23 +114,34 @@ func (ntgs *NodeTargetGroupSyncer) synchronizeNodesWithTargetGroups(ctx context.
 		return nil
 	}
 
-	newSet := mapset.NewSetFromSlice(nodeTargetGroupSyncState(nodes))
+	eligibleNodes := make([]*corev1.Node, 0, len(nodes))
+	for _, node := range nodes {
+		if node.Spec.ProviderID == "" {
+			klog.Warningf("node %s ProviderID is empty, skipping target group synchronization for this node", node.Name)
+			continue
+		}
+
+		if !strings.Contains(node.Spec.ProviderID, "yandex") {
+			log.Printf("node %s ProviderID is not yandex (%s), skipping", node.Name, node.Spec.ProviderID)
+			continue
+		}
+
+		eligibleNodes = append(eligibleNodes, node)
+	}
+
+	if len(eligibleNodes) == 0 {
+		klog.Warning("no nodes with valid Yandex ProviderID to synchronize TGs with, skipping...")
+		return nil
+	}
+
+	newSet := mapset.NewSetFromSlice(nodeTargetGroupSyncState(eligibleNodes))
 	if ntgs.lastVisitedNodes.Equal(newSet) {
 		return nil
 	}
 
 	// TODO: speed up by not performing individual lookups
 	var instances []*instanceWithNodeInfo
-	for _, node := range nodes {
-		if node.Spec.ProviderID == "" {
-			return errors.Errorf("node %s ProviderID is empty", node.Name)
-		}
-
-		if !(strings.Contains(node.Spec.ProviderID, "yandex")) {
-			log.Printf("node %s ProviderID is not yandex (%s), skipping", node.Name, node.Spec.ProviderID)
-			continue
-		}
-
+	for _, node := range eligibleNodes {
 		nodeName := MapNodeNameToInstanceName(types.NodeName(node.Name))
 		log.Printf("Finding Instance by Folder %q and Name %q", ntgs.cloud.config.FolderID, nodeName)
 		instance, err := ntgs.cloud.yandexService.ComputeSvc.FindInstanceByName(ctx, nodeName)

--- a/pkg/cloudprovider/yandex/load_balancer_tg_controller.go
+++ b/pkg/cloudprovider/yandex/load_balancer_tg_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"sync"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/yandex-cloud/go-genproto/yandex/cloud/vpc/v1"
 	corev1 "k8s.io/api/core/v1"
 	cloudprovider "k8s.io/cloud-provider"
+	cloudproviderapi "k8s.io/cloud-provider/api"
 
 	corev1listers "k8s.io/client-go/listers/core/v1"
 
@@ -30,7 +32,7 @@ type NodeTargetGroupSyncer struct {
 	cloud *Cloud
 
 	lastVisitedNodes mapset.Set
-	lastSkippedNodes mapset.Set
+	lastSkippedNodes string
 	serviceLister    corev1listers.ServiceLister
 
 	tgSyncLock sync.Mutex
@@ -99,7 +101,11 @@ func (ntgs *NodeTargetGroupSyncer) cleanUpTargetGroups(ctx context.Context) erro
 		return err
 	}
 
+	// Both caches describe the target groups that were just removed, so neither may outlive them:
+	// keeping lastSkippedNodes would swallow the warning about a Node left out of the target groups
+	// the next time a LoadBalancer Service appears.
 	ntgs.lastVisitedNodes.Clear()
+	ntgs.lastSkippedNodes = ""
 
 	return nil
 }
@@ -109,6 +115,16 @@ type instanceWithNodeInfo struct {
 	Node     *corev1.Node
 }
 
+func hasTaint(node *corev1.Node, key string) bool {
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == key {
+			return true
+		}
+	}
+
+	return false
+}
+
 // partitionNodesByProviderID splits Nodes into the ones that can be placed into a target group
 // and human-readable reasons for the ones that cannot. Nodes without a ProviderID are not an
 // error: a freshly registered Node has no ProviderID until the node controller assigns one, and
@@ -116,14 +132,22 @@ type instanceWithNodeInfo struct {
 //
 // This is a different notion of eligibility from nodeEligibleForLoadBalancer, which filters on
 // Node state – deletion, exclusion label, autoscaler taint – rather than on the ProviderID.
-//
-// Filtering is silent: callers decide what to report, so that a steady-state cluster does not
-// repeat the same per-Node messages at default verbosity on every synchronization.
 func partitionNodesByProviderID(nodes []*corev1.Node) (yandexNodes []*corev1.Node, skipped []string) {
 	yandexNodes = make([]*corev1.Node, 0, len(nodes))
 	for _, node := range nodes {
 		if node.Spec.ProviderID == "" {
-			skipped = append(skipped, fmt.Sprintf("%s (ProviderID is empty)", node.Name))
+			// The taint separates two causes that need different fixes: with it, cloud-node has
+			// simply not initialized the Node yet; without it, the Node was never offered to a
+			// cloud provider – a genuine static Node, or a cloud VM whose kubelet is missing
+			// --cloud-provider=external and which stays out of the target groups until that is
+			// fixed. Naming which one it is turns a silent capacity loss into something actionable.
+			reason := "awaiting cloud-node initialization"
+			if !hasTaint(node, cloudproviderapi.TaintExternalCloudProvider) {
+				reason = fmt.Sprintf("no %s taint, never handed to a cloud provider",
+					cloudproviderapi.TaintExternalCloudProvider)
+			}
+			skipped = append(skipped, fmt.Sprintf("%s (%s)", node.Name, reason))
+
 			continue
 		}
 
@@ -141,25 +165,24 @@ func partitionNodesByProviderID(nodes []*corev1.Node) (yandexNodes []*corev1.Nod
 	return yandexNodes, skipped
 }
 
-// skippedNodesChanged records the Nodes left out of the target groups and reports whether that set
-// differs from the previous synchronization. Skipped Nodes have to be visible at default verbosity
-// – an operator must be able to see that a Node dropped out of the target groups – but a cluster
-// with static Nodes would otherwise repeat the same warning on every synchronization forever.
+// newlySkippedNodes returns the Nodes left out of the target groups rendered for a log line, or an
+// empty string when there is nothing new to report. Skipped Nodes have to be visible at default
+// verbosity – an operator must be able to see that a Node dropped out of the target groups – but a
+// cluster with static Nodes would otherwise repeat the same warning on every synchronization.
 //
-// Node order from the informer is not stable, so this compares sets rather than slices, and a nil
-// lastSkippedNodes counts as changed so the first observation is always reported.
-func (ntgs *NodeTargetGroupSyncer) skippedNodesChanged(skipped []string) bool {
-	current := mapset.NewSet()
-	for _, reason := range skipped {
-		current.Add(reason)
-	}
+// Sorting is what makes the comparison correct at all – Node order from the informer is not stable
+// – and it keeps the reported line stable between reports. The argument is freshly built by
+// partitionNodesByProviderID, so sorting it in place is safe.
+func (ntgs *NodeTargetGroupSyncer) newlySkippedNodes(skipped []string) string {
+	sort.Strings(skipped)
 
-	if ntgs.lastSkippedNodes != nil && ntgs.lastSkippedNodes.Equal(current) {
-		return false
+	current := strings.Join(skipped, "; ")
+	if current == ntgs.lastSkippedNodes {
+		return ""
 	}
 	ntgs.lastSkippedNodes = current
 
-	return true
+	return current
 }
 
 func (ntgs *NodeTargetGroupSyncer) synchronizeNodesWithTargetGroups(ctx context.Context, nodes []*corev1.Node) error {
@@ -172,9 +195,9 @@ func (ntgs *NodeTargetGroupSyncer) synchronizeNodesWithTargetGroups(ctx context.
 
 	// Reported before the lastVisitedNodes check below: a skipped Node never reaches that cache,
 	// so gating this on a changed Node set would hide it entirely.
-	if ntgs.skippedNodesChanged(skippedNodes) && len(skippedNodes) > 0 {
+	if reasons := ntgs.newlySkippedNodes(skippedNodes); reasons != "" {
 		klog.Warningf("skipping %d of %d Nodes during TG synchronization: %s",
-			len(skippedNodes), len(nodes), strings.Join(skippedNodes, "; "))
+			len(skippedNodes), len(nodes), reasons)
 	}
 
 	if len(yandexNodes) == 0 {

--- a/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
+++ b/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
@@ -3,6 +3,8 @@ package yandex
 import (
 	"context"
 	"errors"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -176,5 +178,95 @@ func TestSynchronizeNodesWithTargetGroupsSkipsWhenAllProviderIDsAreEmpty(t *test
 	}
 	if !syncer.lastVisitedNodes.Equal(lastVisitedNodes) {
 		t.Fatal("expected last visited nodes cache to remain unchanged")
+	}
+}
+
+func TestPartitionNodesByProviderIDKeepsYandexNodesAlongsideSkippedOnes(t *testing.T) {
+	// A static Node deliberately comes first: an implementation that aborts on the first
+	// unusable Node instead of skipping it would drop the cloud Nodes that follow.
+	nodes := []*corev1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "static-node"}},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "cloud-node-1"},
+			Spec:       corev1.NodeSpec{ProviderID: "yandex://instance-1"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foreign-node"},
+			Spec:       corev1.NodeSpec{ProviderID: "aws:///eu-central-1a/i-1"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "deprecated-node"},
+			Spec:       corev1.NodeSpec{ProviderID: "yandex://folder/ru-central1-a/instance-3"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "cloud-node-2"},
+			Spec:       corev1.NodeSpec{ProviderID: "yandex://instance-2"},
+		},
+	}
+
+	yandexNodes, skipped := partitionNodesByProviderID(nodes)
+
+	yandexNames := make([]string, 0, len(yandexNodes))
+	for _, node := range yandexNodes {
+		yandexNames = append(yandexNames, node.Name)
+	}
+	expected := []string{"cloud-node-1", "deprecated-node", "cloud-node-2"}
+	if !reflect.DeepEqual(yandexNames, expected) {
+		t.Fatalf("expected Yandex Nodes %v, got %v", expected, yandexNames)
+	}
+
+	if len(skipped) != 2 {
+		t.Fatalf("expected 2 skipped Nodes, got %d: %v", len(skipped), skipped)
+	}
+	for _, want := range []string{"static-node", "foreign-node"} {
+		found := false
+		for _, reason := range skipped {
+			if strings.Contains(reason, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %q to be reported as skipped, got %v", want, skipped)
+		}
+	}
+}
+
+func TestPartitionNodesByProviderIDRejectsForeignProviderIDMentioningYandex(t *testing.T) {
+	// A substring match on "yandex" would accept this Node. Since the Instance is then resolved
+	// by Node name, an unrelated VM sharing that name in the Yandex folder would be attached to
+	// the cluster's target group.
+	nodes := []*corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "impostor-node"},
+			Spec:       corev1.NodeSpec{ProviderID: "aws:///eu-central-1a/i-0yandex123"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "malformed-node"},
+			Spec:       corev1.NodeSpec{ProviderID: "yandex://"},
+		},
+	}
+
+	yandexNodes, skipped := partitionNodesByProviderID(nodes)
+	if len(yandexNodes) != 0 {
+		t.Fatalf("expected no Yandex Nodes, got %v", yandexNodes)
+	}
+	if len(skipped) != 2 {
+		t.Fatalf("expected both Nodes to be reported as skipped, got %v", skipped)
+	}
+}
+
+func TestPartitionNodesByProviderIDReturnsNoNodesWhenProviderIDsAreEmpty(t *testing.T) {
+	nodes := []*corev1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "stale-node-1"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "stale-node-2"}},
+	}
+
+	yandexNodes, skipped := partitionNodesByProviderID(nodes)
+	if len(yandexNodes) != 0 {
+		t.Fatalf("expected no Yandex Nodes, got %d", len(yandexNodes))
+	}
+	if len(skipped) != 2 {
+		t.Fatalf("expected both Nodes to be reported as skipped, got %v", skipped)
 	}
 }

--- a/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
+++ b/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
@@ -8,9 +8,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/yandex-cloud/go-genproto/yandex/cloud/loadbalancer/v1"
+	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
+	cloudproviderapi "k8s.io/cloud-provider/api"
+
+	"github.com/deckhouse/yandex-cloud-controller-manager/pkg/yapi"
 
 	mapset "github.com/deckarep/golang-set"
 )
@@ -215,20 +220,9 @@ func TestPartitionNodesByProviderIDKeepsYandexNodesAlongsideSkippedOnes(t *testi
 		t.Fatalf("expected Yandex Nodes %v, got %v", expected, yandexNames)
 	}
 
-	if len(skipped) != 2 {
-		t.Fatalf("expected 2 skipped Nodes, got %d: %v", len(skipped), skipped)
-	}
-	for _, want := range []string{"static-node", "foreign-node"} {
-		found := false
-		for _, reason := range skipped {
-			if strings.Contains(reason, want) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("expected %q to be reported as skipped, got %v", want, skipped)
-		}
+	// Reasons keep Node order, so the two skipped Nodes are pinned positionally.
+	if len(skipped) != 2 || !strings.Contains(skipped[0], "static-node") || !strings.Contains(skipped[1], "foreign-node") {
+		t.Fatalf("expected static-node and foreign-node to be reported as skipped, got %v", skipped)
 	}
 }
 
@@ -256,10 +250,52 @@ func TestPartitionNodesByProviderIDRejectsForeignProviderIDMentioningYandex(t *t
 	}
 }
 
-func TestPartitionNodesByProviderIDReturnsNoNodesWhenProviderIDsAreEmpty(t *testing.T) {
+func TestNewlySkippedNodesReportsOnlyOnChange(t *testing.T) {
+	syncer := &NodeTargetGroupSyncer{}
+	first := []string{"static-2 (ProviderID is empty)", "static-1 (ProviderID is empty)"}
+
+	reported := syncer.newlySkippedNodes(first)
+	if reported == "" {
+		t.Fatal("the first observation of skipped Nodes must be reported")
+	}
+	// Reported reasons are sorted, so the log line stays stable between reports even though the
+	// informer hands Nodes over in no particular order.
+	if reported != "static-1 (ProviderID is empty); static-2 (ProviderID is empty)" {
+		t.Fatalf("expected the reported reasons to be sorted, got %q", reported)
+	}
+
+	// Same Nodes in a different order are the same set and must not be reported again.
+	if again := syncer.newlySkippedNodes([]string{first[1], first[0]}); again != "" {
+		t.Fatalf("an unchanged set of skipped Nodes must not be reported again, got %q", again)
+	}
+
+	grown := []string{first[0], first[1], "static-3 (ProviderID is empty)"}
+	if syncer.newlySkippedNodes(grown) == "" {
+		t.Fatal("a newly skipped Node must be reported")
+	}
+
+	// Nothing skipped any more: the state has to be cleared so a later skip is reported again,
+	// while the transition itself has nothing to log.
+	if empty := syncer.newlySkippedNodes(nil); empty != "" {
+		t.Fatalf("an empty set of skipped Nodes has nothing to report, got %q", empty)
+	}
+	if syncer.newlySkippedNodes(grown) == "" {
+		t.Fatal("skipped Nodes returning after an empty set must be reported again")
+	}
+}
+
+func TestPartitionNodesByProviderIDDistinguishesUninitializedFromStaticNodes(t *testing.T) {
+	// PR #195 hit this in production: a Node reaching reconciliation with an empty ProviderID.
+	// Whose problem it is depends entirely on the taint, so the reasons have to differ.
 	nodes := []*corev1.Node{
-		{ObjectMeta: metav1.ObjectMeta{Name: "stale-node-1"}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "stale-node-2"}},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "awaiting-init"},
+			Spec: corev1.NodeSpec{Taints: []corev1.Taint{{
+				Key:    cloudproviderapi.TaintExternalCloudProvider,
+				Effect: corev1.TaintEffectNoSchedule,
+			}}},
+		},
+		{ObjectMeta: metav1.ObjectMeta{Name: "never-offered"}},
 	}
 
 	yandexNodes, skipped := partitionNodesByProviderID(nodes)
@@ -269,30 +305,58 @@ func TestPartitionNodesByProviderIDReturnsNoNodesWhenProviderIDsAreEmpty(t *test
 	if len(skipped) != 2 {
 		t.Fatalf("expected both Nodes to be reported as skipped, got %v", skipped)
 	}
+
+	if !strings.Contains(skipped[0], "awaiting cloud-node initialization") {
+		t.Errorf("a Node carrying the %s taint must be reported as awaiting initialization, got %q",
+			cloudproviderapi.TaintExternalCloudProvider, skipped[0])
+	}
+	if !strings.Contains(skipped[1], "never handed to a cloud provider") {
+		t.Errorf("a Node without the taint must be reported as never handed to a cloud provider, got %q", skipped[1])
+	}
+	// The two causes need different remediation, so they must not collapse into one message.
+	if skipped[0] == skipped[1] {
+		t.Fatal("the two causes of an empty ProviderID must produce different reasons")
+	}
 }
 
-func TestSkippedNodesChangedReportsOnlyOnChange(t *testing.T) {
-	syncer := &NodeTargetGroupSyncer{}
-	first := []string{"static-1 (ProviderID is empty)", "static-2 (ProviderID is empty)"}
+// fakeEmptyTargetGroupClient reports no target groups, which is enough to walk
+// cleanUpTargetGroups down to the cache reset without any operations to wait on.
+type fakeEmptyTargetGroupClient struct {
+	loadbalancer.TargetGroupServiceClient
+}
 
-	if !syncer.skippedNodesChanged(first) {
+func (fakeEmptyTargetGroupClient) List(_ context.Context, _ *loadbalancer.ListTargetGroupsRequest, _ ...grpc.CallOption) (*loadbalancer.ListTargetGroupsResponse, error) {
+	return &loadbalancer.ListTargetGroupsResponse{}, nil
+}
+
+func TestCleanUpTargetGroupsResetsSkippedNodeReport(t *testing.T) {
+	// Both caches describe target groups that cleanUpTargetGroups has just removed. If the skipped
+	// Node report survives them, the next LoadBalancer Service is created without any warning that
+	// a Node is being left out of its target groups.
+	syncer := &NodeTargetGroupSyncer{
+		cloud: &Cloud{
+			config: CloudConfig{ClusterName: "test-cluster"},
+			yandexService: &yapi.YandexCloudAPI{
+				LbSvc: yapi.NewLoadBalancerService(nil, fakeEmptyTargetGroupClient{}, &yapi.CloudContext{FolderID: "test-folder"}),
+			},
+		},
+		lastVisitedNodes: mapset.NewSet(),
+	}
+
+	skipped := []string{"static-1 (never handed to a cloud provider)"}
+	if syncer.newlySkippedNodes(skipped) == "" {
 		t.Fatal("the first observation of skipped Nodes must be reported")
 	}
-	// Node listings from the informer are not ordered, so a reshuffled slice is the same set and
-	// must not produce another warning.
-	if syncer.skippedNodesChanged([]string{first[1], first[0]}) {
-		t.Fatal("an unchanged set of skipped Nodes must not be reported again")
+	syncer.lastVisitedNodes.Add("stale")
+
+	if err := syncer.cleanUpTargetGroups(context.Background()); err != nil {
+		t.Fatalf("cleanUpTargetGroups: %v", err)
 	}
 
-	grown := []string{first[0], first[1], "static-3 (ProviderID is empty)"}
-	if !syncer.skippedNodesChanged(grown) {
-		t.Fatal("a newly skipped Node must be reported")
+	if syncer.lastVisitedNodes.Cardinality() != 0 {
+		t.Errorf("expected the visited Node cache to be cleared, got %v", syncer.lastVisitedNodes)
 	}
-
-	if !syncer.skippedNodesChanged(nil) {
-		t.Fatal("Nodes no longer being skipped must be reported")
-	}
-	if syncer.skippedNodesChanged(nil) {
-		t.Fatal("an empty set of skipped Nodes must not be reported twice")
+	if syncer.newlySkippedNodes(skipped) == "" {
+		t.Error("after the target groups are torn down the same skipped Nodes must be reported again")
 	}
 }

--- a/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
+++ b/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
@@ -162,3 +162,19 @@ func TestTargetGroupSyncWorkerStopsOnContextCancellation(t *testing.T) {
 		t.Fatal("target group sync worker did not stop after context cancellation")
 	}
 }
+
+func TestSynchronizeNodesWithTargetGroupsSkipsWhenAllProviderIDsAreEmpty(t *testing.T) {
+	lastVisitedNodes := mapset.NewSet("previous-node")
+	syncer := &NodeTargetGroupSyncer{lastVisitedNodes: lastVisitedNodes}
+	nodes := []*corev1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "stale-node-1"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "stale-node-2"}},
+	}
+
+	if err := syncer.synchronizeNodesWithTargetGroups(context.Background(), nodes); err != nil {
+		t.Fatalf("expected synchronization to be skipped, got error: %v", err)
+	}
+	if !syncer.lastVisitedNodes.Equal(lastVisitedNodes) {
+		t.Fatal("expected last visited nodes cache to remain unchanged")
+	}
+}

--- a/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
+++ b/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
@@ -270,3 +270,29 @@ func TestPartitionNodesByProviderIDReturnsNoNodesWhenProviderIDsAreEmpty(t *test
 		t.Fatalf("expected both Nodes to be reported as skipped, got %v", skipped)
 	}
 }
+
+func TestSkippedNodesChangedReportsOnlyOnChange(t *testing.T) {
+	syncer := &NodeTargetGroupSyncer{}
+	first := []string{"static-1 (ProviderID is empty)", "static-2 (ProviderID is empty)"}
+
+	if !syncer.skippedNodesChanged(first) {
+		t.Fatal("the first observation of skipped Nodes must be reported")
+	}
+	// Node listings from the informer are not ordered, so a reshuffled slice is the same set and
+	// must not produce another warning.
+	if syncer.skippedNodesChanged([]string{first[1], first[0]}) {
+		t.Fatal("an unchanged set of skipped Nodes must not be reported again")
+	}
+
+	grown := []string{first[0], first[1], "static-3 (ProviderID is empty)"}
+	if !syncer.skippedNodesChanged(grown) {
+		t.Fatal("a newly skipped Node must be reported")
+	}
+
+	if !syncer.skippedNodesChanged(nil) {
+		t.Fatal("Nodes no longer being skipped must be reported")
+	}
+	if syncer.skippedNodesChanged(nil) {
+		t.Fatal("an empty set of skipped Nodes must not be reported twice")
+	}
+}


### PR DESCRIPTION
A Node that cannot be resolved to a Yandex Instance no longer aborts target group
synchronization for the whole cluster. Such Nodes are left out of the target groups; every
other Node is synchronized as usual. Two cases:

- **Empty `spec.providerID`** — the permanent state of a static Node in a hybrid cluster, and
  the transient state of any cloud Node before `cloud-node` assigns its ProviderID. Previously
  `synchronizeNodesWithTargetGroups` returned `node %s ProviderID is empty`, so no `Service` of
  type `LoadBalancer` could be reconciled while such a Node existed — `ensureLB` kept failing
  with `TG does not exist yet`.
- **Deleted Instance** — the lookup now goes through `getInstanceByProviderID`, which reports a
  missing Instance as `cloudprovider.InstanceNotFound`. That Node is skipped; network and
  server-side errors still fail the synchronization.

  `lastVisitedNodes` now stores the set that was **achieved** rather than the one that was
  desired, so a Node skipped because its Instance is gone is retried on the next synchronization
  instead of being pinned until an unrelated change. This is what makes it safe to relax the hard
  error that #146 added deliberately, and it is the invariant #197 fixed the cache for.

- **Stricter ProviderID validation.** `strings.Contains(providerID, "yandex")` is replaced with
  the existing `ParseProviderID`, anchored on `^yandex://`. Not separable — `getInstanceByProviderID`
  consumes its result. Also one `Get` by ID instead of a folder-wide `List` by Node name, which
  is the `TODO: speed up by not performing individual lookups` above that loop.
- **Diagnostics.** Skipped Nodes are reported at default verbosity, but only when that set
  changes. An empty `providerID` now says which of two causes it is, using the
  `node.cloudprovider.kubernetes.io/uninitialized` taint: `cloud-node` has not gotten to the Node
  yet, or the Node was never handed to a cloud provider at all (a static Node, or a cloud VM whose
  kubelet is missing `--cloud-provider=external`). The `ensureLB` error now names both reasons a
  target group can be absent.
