### PR TITLE
report why a Node is left out of the target groups

### DIFF
--- a/pkg/cloudprovider/yandex/cloud.go
+++ b/pkg/cloudprovider/yandex/cloud.go
@@ -188,10 +188,8 @@ func nodeEligibleForLoadBalancer(node *corev1.Node) bool {
 	if _, excluded := node.Labels[corev1.LabelNodeExcludeBalancers]; excluded {
 		return false
 	}
-	for _, taint := range node.Spec.Taints {
-		if taint.Key == "ToBeDeletedByClusterAutoscaler" {
-			return false
-		}
+	if hasTaint(node, "ToBeDeletedByClusterAutoscaler") {
+		return false
 	}
 	return true
 }
@@ -281,7 +279,6 @@ func (yc *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder,
 		cloud:            yc,
 		serviceLister:    serviceInformer.Lister(),
 		lastVisitedNodes: mapset.NewSet(),
-		lastSkippedNodes: mapset.NewSet(),
 	}
 
 	yc.nodeLister = nodeInformer.Lister()

--- a/pkg/cloudprovider/yandex/load_balancer_tg_controller.go
+++ b/pkg/cloudprovider/yandex/load_balancer_tg_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"sync"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/yandex-cloud/go-genproto/yandex/cloud/vpc/v1"
 	corev1 "k8s.io/api/core/v1"
 	cloudprovider "k8s.io/cloud-provider"
+	cloudproviderapi "k8s.io/cloud-provider/api"
 
 	corev1listers "k8s.io/client-go/listers/core/v1"
 
@@ -30,7 +32,7 @@ type NodeTargetGroupSyncer struct {
 	cloud *Cloud
 
 	lastVisitedNodes mapset.Set
-	lastSkippedNodes mapset.Set
+	lastSkippedNodes string
 	serviceLister    corev1listers.ServiceLister
 
 	tgSyncLock sync.Mutex
@@ -99,7 +101,11 @@ func (ntgs *NodeTargetGroupSyncer) cleanUpTargetGroups(ctx context.Context) erro
 		return err
 	}
 
+	// Both caches describe the target groups that were just removed, so neither may outlive them:
+	// keeping lastSkippedNodes would swallow the warning about a Node left out of the target groups
+	// the next time a LoadBalancer Service appears.
 	ntgs.lastVisitedNodes.Clear()
+	ntgs.lastSkippedNodes = ""
 
 	return nil
 }
@@ -107,6 +113,16 @@ func (ntgs *NodeTargetGroupSyncer) cleanUpTargetGroups(ctx context.Context) erro
 type instanceWithNodeInfo struct {
 	Instance *compute.Instance
 	Node     *corev1.Node
+}
+
+func hasTaint(node *corev1.Node, key string) bool {
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == key {
+			return true
+		}
+	}
+
+	return false
 }
 
 // partitionNodesByProviderID splits Nodes into the ones that can be placed into a target group
@@ -123,7 +139,20 @@ func partitionNodesByProviderID(nodes []*corev1.Node) (yandexNodes []*corev1.Nod
 	yandexNodes = make([]*corev1.Node, 0, len(nodes))
 	for _, node := range nodes {
 		if node.Spec.ProviderID == "" {
-			skipped = append(skipped, fmt.Sprintf("%s (ProviderID is empty)", node.Name))
+			// Two very different causes hide behind an empty ProviderID, and the taint tells them
+			// apart for free. With the taint, kubelet did hand the Node to a cloud provider and
+			// cloud-node has simply not initialized it yet, which normally takes seconds. Without
+			// it, the Node was never offered to a cloud provider at all: either a genuine static
+			// Node, or a cloud VM whose kubelet is missing --cloud-provider=external – and in that
+			// second case the Node stays out of the target groups until that is fixed, so saying
+			// which of the two it is turns a silent capacity loss into something actionable.
+			reason := "awaiting cloud-node initialization"
+			if !hasTaint(node, cloudproviderapi.TaintExternalCloudProvider) {
+				reason = fmt.Sprintf("no %s taint, never handed to a cloud provider",
+					cloudproviderapi.TaintExternalCloudProvider)
+			}
+			skipped = append(skipped, fmt.Sprintf("%s (%s)", node.Name, reason))
+
 			continue
 		}
 
@@ -141,25 +170,24 @@ func partitionNodesByProviderID(nodes []*corev1.Node) (yandexNodes []*corev1.Nod
 	return yandexNodes, skipped
 }
 
-// skippedNodesChanged records the Nodes left out of the target groups and reports whether that set
-// differs from the previous synchronization. Skipped Nodes have to be visible at default verbosity
-// – an operator must be able to see that a Node dropped out of the target groups – but a cluster
-// with static Nodes would otherwise repeat the same warning on every synchronization forever.
+// newlySkippedNodes returns the Nodes left out of the target groups rendered for a log line, or an
+// empty string when there is nothing new to report. Skipped Nodes have to be visible at default
+// verbosity – an operator must be able to see that a Node dropped out of the target groups – but a
+// cluster with static Nodes would otherwise repeat the same warning on every synchronization.
 //
-// Node order from the informer is not stable, so this compares sets rather than slices, and a nil
-// lastSkippedNodes counts as changed so the first observation is always reported.
-func (ntgs *NodeTargetGroupSyncer) skippedNodesChanged(skipped []string) bool {
-	current := mapset.NewSet()
-	for _, reason := range skipped {
-		current.Add(reason)
-	}
+// Sorting does double duty: Node order from the informer is not stable, so unsorted reasons would
+// compare unequal at random, and it keeps the reported line itself stable between reports. The
+// argument is a freshly built slice, so sorting it in place is safe.
+func (ntgs *NodeTargetGroupSyncer) newlySkippedNodes(skipped []string) string {
+	sort.Strings(skipped)
 
-	if ntgs.lastSkippedNodes != nil && ntgs.lastSkippedNodes.Equal(current) {
-		return false
+	current := strings.Join(skipped, "; ")
+	if current == ntgs.lastSkippedNodes {
+		return ""
 	}
 	ntgs.lastSkippedNodes = current
 
-	return true
+	return current
 }
 
 func (ntgs *NodeTargetGroupSyncer) synchronizeNodesWithTargetGroups(ctx context.Context, nodes []*corev1.Node) error {
@@ -172,9 +200,9 @@ func (ntgs *NodeTargetGroupSyncer) synchronizeNodesWithTargetGroups(ctx context.
 
 	// Reported before the lastVisitedNodes check below: a skipped Node never reaches that cache,
 	// so gating this on a changed Node set would hide it entirely.
-	if ntgs.skippedNodesChanged(skippedNodes) && len(skippedNodes) > 0 {
+	if reasons := ntgs.newlySkippedNodes(skippedNodes); reasons != "" {
 		klog.Warningf("skipping %d of %d Nodes during TG synchronization: %s",
-			len(skippedNodes), len(nodes), strings.Join(skippedNodes, "; "))
+			len(skippedNodes), len(nodes), reasons)
 	}
 
 	if len(yandexNodes) == 0 {

--- a/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
+++ b/pkg/cloudprovider/yandex/load_balancer_tg_controller_test.go
@@ -8,9 +8,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/yandex-cloud/go-genproto/yandex/cloud/loadbalancer/v1"
+	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
+	cloudproviderapi "k8s.io/cloud-provider/api"
+
+	"github.com/deckhouse/yandex-cloud-controller-manager/pkg/yapi"
 
 	mapset "github.com/deckarep/golang-set"
 )
@@ -271,28 +276,113 @@ func TestPartitionNodesByProviderIDReturnsNoNodesWhenProviderIDsAreEmpty(t *test
 	}
 }
 
-func TestSkippedNodesChangedReportsOnlyOnChange(t *testing.T) {
+func TestNewlySkippedNodesReportsOnlyOnChange(t *testing.T) {
 	syncer := &NodeTargetGroupSyncer{}
-	first := []string{"static-1 (ProviderID is empty)", "static-2 (ProviderID is empty)"}
+	first := []string{"static-2 (ProviderID is empty)", "static-1 (ProviderID is empty)"}
 
-	if !syncer.skippedNodesChanged(first) {
+	reported := syncer.newlySkippedNodes(first)
+	if reported == "" {
 		t.Fatal("the first observation of skipped Nodes must be reported")
 	}
-	// Node listings from the informer are not ordered, so a reshuffled slice is the same set and
-	// must not produce another warning.
-	if syncer.skippedNodesChanged([]string{first[1], first[0]}) {
-		t.Fatal("an unchanged set of skipped Nodes must not be reported again")
+	// Reported reasons are sorted, so the log line stays stable between reports even though the
+	// informer hands Nodes over in no particular order.
+	if reported != "static-1 (ProviderID is empty); static-2 (ProviderID is empty)" {
+		t.Fatalf("expected the reported reasons to be sorted, got %q", reported)
+	}
+
+	// Same Nodes in a different order are the same set and must not be reported again.
+	if again := syncer.newlySkippedNodes([]string{first[1], first[0]}); again != "" {
+		t.Fatalf("an unchanged set of skipped Nodes must not be reported again, got %q", again)
 	}
 
 	grown := []string{first[0], first[1], "static-3 (ProviderID is empty)"}
-	if !syncer.skippedNodesChanged(grown) {
+	if syncer.newlySkippedNodes(grown) == "" {
 		t.Fatal("a newly skipped Node must be reported")
 	}
 
-	if !syncer.skippedNodesChanged(nil) {
-		t.Fatal("Nodes no longer being skipped must be reported")
+	// Nothing skipped any more: the state has to be cleared so a later skip is reported again,
+	// while the transition itself has nothing to log.
+	if empty := syncer.newlySkippedNodes(nil); empty != "" {
+		t.Fatalf("an empty set of skipped Nodes has nothing to report, got %q", empty)
 	}
-	if syncer.skippedNodesChanged(nil) {
-		t.Fatal("an empty set of skipped Nodes must not be reported twice")
+	if syncer.newlySkippedNodes(grown) == "" {
+		t.Fatal("skipped Nodes returning after an empty set must be reported again")
+	}
+}
+
+func TestPartitionNodesByProviderIDDistinguishesUninitializedFromStaticNodes(t *testing.T) {
+	// PR #195 hit this in production: a Node reaching reconciliation with an empty ProviderID.
+	// Whose problem it is depends entirely on the taint, so the reasons have to differ.
+	nodes := []*corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "awaiting-init"},
+			Spec: corev1.NodeSpec{Taints: []corev1.Taint{{
+				Key:    cloudproviderapi.TaintExternalCloudProvider,
+				Effect: corev1.TaintEffectNoSchedule,
+			}}},
+		},
+		{ObjectMeta: metav1.ObjectMeta{Name: "never-offered"}},
+	}
+
+	yandexNodes, skipped := partitionNodesByProviderID(nodes)
+	if len(yandexNodes) != 0 {
+		t.Fatalf("expected no Yandex Nodes, got %d", len(yandexNodes))
+	}
+	if len(skipped) != 2 {
+		t.Fatalf("expected both Nodes to be reported as skipped, got %v", skipped)
+	}
+
+	if !strings.Contains(skipped[0], "awaiting cloud-node initialization") {
+		t.Errorf("a Node carrying the %s taint must be reported as awaiting initialization, got %q",
+			cloudproviderapi.TaintExternalCloudProvider, skipped[0])
+	}
+	if !strings.Contains(skipped[1], "never handed to a cloud provider") {
+		t.Errorf("a Node without the taint must be reported as never handed to a cloud provider, got %q", skipped[1])
+	}
+	// The two causes need different remediation, so they must not collapse into one message.
+	if skipped[0] == skipped[1] {
+		t.Fatal("the two causes of an empty ProviderID must produce different reasons")
+	}
+}
+
+// fakeEmptyTargetGroupClient reports no target groups, which is enough to walk
+// cleanUpTargetGroups down to the cache reset without any operations to wait on.
+type fakeEmptyTargetGroupClient struct {
+	loadbalancer.TargetGroupServiceClient
+}
+
+func (fakeEmptyTargetGroupClient) List(_ context.Context, _ *loadbalancer.ListTargetGroupsRequest, _ ...grpc.CallOption) (*loadbalancer.ListTargetGroupsResponse, error) {
+	return &loadbalancer.ListTargetGroupsResponse{}, nil
+}
+
+func TestCleanUpTargetGroupsResetsSkippedNodeReport(t *testing.T) {
+	// Both caches describe target groups that cleanUpTargetGroups has just removed. If the skipped
+	// Node report survives them, the next LoadBalancer Service is created without any warning that
+	// a Node is being left out of its target groups.
+	syncer := &NodeTargetGroupSyncer{
+		cloud: &Cloud{
+			config: CloudConfig{ClusterName: "test-cluster"},
+			yandexService: &yapi.YandexCloudAPI{
+				LbSvc: yapi.NewLoadBalancerService(nil, fakeEmptyTargetGroupClient{}, &yapi.CloudContext{FolderID: "test-folder"}),
+			},
+		},
+		lastVisitedNodes: mapset.NewSet(),
+	}
+
+	skipped := []string{"static-1 (never handed to a cloud provider)"}
+	if syncer.newlySkippedNodes(skipped) == "" {
+		t.Fatal("the first observation of skipped Nodes must be reported")
+	}
+	syncer.lastVisitedNodes.Add("stale")
+
+	if err := syncer.cleanUpTargetGroups(context.Background()); err != nil {
+		t.Fatalf("cleanUpTargetGroups: %v", err)
+	}
+
+	if syncer.lastVisitedNodes.Cardinality() != 0 {
+		t.Errorf("expected the visited Node cache to be cleared, got %v", syncer.lastVisitedNodes)
+	}
+	if syncer.newlySkippedNodes(skipped) == "" {
+		t.Error("after the target groups are torn down the same skipped Nodes must be reported again")
 	}
 }


### PR DESCRIPTION
## What

Improves the report about Nodes that target group synchronization leaves out.

**Says which of two causes an empty `spec.providerID` is.** The two need completely
different remediation, and skipping the Node without naming the cause turns a real
capacity loss into a silent one. The `node.cloudprovider.kubernetes.io/uninitialized`
taint tells them apart at no cost — it sits on the Node object, so no cloud API call
is involved:

| Node state | What it means | Reported as |
|---|---|---|
| Taint present | kubelet did hand the Node to a cloud provider and `cloud-node` has not initialized it yet, normally a matter of seconds | `awaiting cloud-node initialization` |
| Taint absent | the Node was never offered to a cloud provider: either a genuine static Node, or a cloud VM whose kubelet is missing `--cloud-provider=external` | `no <taint> taint, never handed to a cloud provider` |

**Simplifies the bookkeeping behind that report.** `lastSkippedNodes` goes from a
`mapset.Set` to the rendered string, so the accumulation loop, the nil guard and a
duplicate `strings.Join` disappear, and the zero value means "nothing skipped before"
on its own. Reasons are sorted, which is what makes the comparison correct — Node
order from the informer is not stable — and also keeps the logged line stable between
reports.

`hasTaint` is shared with `nodeEligibleForLoadBalancer`, which carried the same loop.

## Why not backfill the ProviderID instead

#195 hit the second case in production and proposed resolving the Instance by Node
name and patching `spec.providerID`. That was not taken:

- `spec.providerID` is immutable once set, and the value would come from a Node-name
  lookup, so a wrong match becomes permanent — unfixable without deleting the Node
  object.
- `cloud-node` already owns this: it sets `spec.ProviderID` when empty, using the same
  name-based fallback. Doing it again from the load balancer path races that controller.
- The root cause is cluster configuration, which also affects Node addresses, zones and
  instance types — far more than load balancers.

Reporting which cause it is, is the part that belongs in the target group syncer.

## Base

Based on `fix/skip-empty-provider-id-nodes` (#198), not on `master`: this changes
`partitionNodesByProviderID`, which #198 introduces. GitHub will retarget this PR to
`master` once #198 merges.

## Testing

`go build ./...`, `go vet ./pkg/...`, `go test ./pkg/...`.

`TestPartitionNodesByProviderIDDistinguishesUninitializedFromStaticNodes` asserts the
two causes produce different messages. `TestNewlySkippedNodesReportsOnlyOnChange`
covers the dedup, including that reasons are sorted and that a reshuffled slice is
treated as unchanged. Both were verified by mutation — inverting the taint check and
dropping the sort each make the corresponding test fail.
